### PR TITLE
Feat/mail

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,12 @@
+DB_HOST=string
+DB_PORT=number
+DB_NAME=string
+DB_USERNAME=string
+DB_PASSWORD=string
+
 JWT_SECRET=string
+
+MAIL_HOST=string
+MAIL_PORT=number
+MAIL_USERNAME=string
+MAIL_PASSWORD=string

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,11 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	implementation 'com.sun.mail:jakarta.mail:2.0.1'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	implementation 'org.apache.commons:commons-lang3:3.0'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/docs/asciidoc/user.adoc
+++ b/src/docs/asciidoc/user.adoc
@@ -11,14 +11,15 @@ include::{snippets}/user-controller-test/유저를_생성한다/request-fields.a
 ==== 요청
 include::{snippets}/user-controller-test/유저를_생성한다/http-request.adoc[]
 
-
 ==== 응답
 ===== 정상 응답
 include::{snippets}/user-controller-test/유저를_생성한다/http-response.adoc[]
 
-==== 잘못된 인증 코드인 경우
-인증 요청을 하지 않았거나, 유효 시간이 만료되었거나, 인증 코드가 틀린 경우 모두 포함되어 처리됩니다.
-include::{snippets}/user-controller-test/유저를_생성할_때_인증되지_않은_이메일이라면_에러가_발생한다/http-response.adoc[]
+==== 이메일 인증 요청을 하지 않았거나 유효 시간이 만료된 경우
+include::{snippets}/user-controller-test/유저를_생성할_때_인증하지_않은_이메일이거나_만료된_이메일이라면_에러가_발생한다/http-response.adoc[]
+
+==== 인증 코드가 틀린 경우
+include::{snippets}/user-controller-test/유저를_생성할_때_인증_코드가_틀렸으면_에러가_발생한다/http-response.adoc[]
 
 ===== 이미 가입한 유저가 있는 경우
 include::{snippets}/user-controller-test/유저를_생성할_때_이미_유저가_있다면_에러가_발생한다/http-response.adoc[]
@@ -28,6 +29,20 @@ include::{snippets}/user-controller-test/유저를_생성할_때_잘못된_형�
 
 === 이메일 인증 요청
 
+이메일을 입력해 이메일 인증을 요청할 수 있습니다.
+
+해당 API에 요청을 보내게 되면, 입력받은 이메일로 인증 코드를 전송합니다.
+
+이 인증 코드는 5분간 유효합니다.
+
 ==== 요청 형식
 
-===== RequestParam
+===== Query Parameter
+include::{snippets}/user-controller-test/이메일_인증을_요청한다/query-parameters.adoc[]
+
+==== 요청
+include::{snippets}/user-controller-test/이메일_인증을_요청한다/http-request.adoc[]
+
+==== 응답
+===== 정상 응답
+include::{snippets}/user-controller-test/이메일_인증을_요청한다/http-response.adoc[]

--- a/src/docs/asciidoc/user.adoc
+++ b/src/docs/asciidoc/user.adoc
@@ -46,3 +46,9 @@ include::{snippets}/user-controller-test/이메일_인증을_요청한다/http-r
 ==== 응답
 ===== 정상 응답
 include::{snippets}/user-controller-test/이메일_인증을_요청한다/http-response.adoc[]
+
+===== 요청 형식이 틀린 경우
+include::{snippets}/user-controller-test/이메일_인증을_요청할_때_잘못된_형식의_이메일을_보내면_에러가_발생한다/http-response.adoc[]
+
+===== 이메일 전송이 실패한 경우
+include::{snippets}/user-controller-test/이메일_인증을_요청할_때_이메일_전송이_실패하면_에러가_발생한다/http-response.adoc[]

--- a/src/docs/asciidoc/user.adoc
+++ b/src/docs/asciidoc/user.adoc
@@ -16,8 +16,18 @@ include::{snippets}/user-controller-test/유저를_생성한다/http-request.ado
 ===== 정상 응답
 include::{snippets}/user-controller-test/유저를_생성한다/http-response.adoc[]
 
+==== 잘못된 인증 코드인 경우
+인증 요청을 하지 않았거나, 유효 시간이 만료되었거나, 인증 코드가 틀린 경우 모두 포함되어 처리됩니다.
+include::{snippets}/user-controller-test/유저를_생성할_때_인증되지_않은_이메일이라면_에러가_발생한다/http-response.adoc[]
+
 ===== 이미 가입한 유저가 있는 경우
 include::{snippets}/user-controller-test/유저를_생성할_때_이미_유저가_있다면_에러가_발생한다/http-response.adoc[]
 
 ===== 요청 형식이 틀린 경우
 include::{snippets}/user-controller-test/유저를_생성할_때_잘못된_형식의_요청을_보내면_에러가_발생한다/http-response.adoc[]
+
+=== 이메일 인증 요청
+
+==== 요청 형식
+
+===== RequestParam

--- a/src/main/java/com/bamdoliro/maru/application/user/SendEmailVerificationUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/user/SendEmailVerificationUseCase.java
@@ -4,29 +4,28 @@ import com.bamdoliro.maru.domain.user.domain.EmailVerification;
 import com.bamdoliro.maru.infrastructure.mail.SendEmailService;
 import com.bamdoliro.maru.infrastructure.persistence.user.EmailVerificationRepository;
 import com.bamdoliro.maru.shared.annotation.UseCase;
-import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
 import org.thymeleaf.ITemplateEngine;
 import org.thymeleaf.context.Context;
-
-import java.io.UnsupportedEncodingException;
 
 @RequiredArgsConstructor
 @UseCase
 public class SendEmailVerificationUseCase {
 
-    private final EmailVerificationRepository emailVerificationRepository;
-    private final SendEmailService sendEmailService;
     private final ITemplateEngine templateEngine;
+    private final SendEmailService sendEmailService;
+    private final EmailVerificationRepository emailVerificationRepository;
 
-    public void execute(String email) throws MessagingException, UnsupportedEncodingException {
-        EmailVerification verification = emailVerificationRepository.save(new EmailVerification(email));
+    public void execute(String email) {
+        EmailVerification verification = new EmailVerification(email);
 
         sendEmailService.execute(
                 email,
                 "[부산소프트웨어마이스터고] 이메일 인증을 요청했습니다.",
                 setContext(verification.getCode())
         );
+
+        emailVerificationRepository.save(verification);
     }
 
     private String setContext(String code) {

--- a/src/main/java/com/bamdoliro/maru/application/user/SendEmailVerificationUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/user/SendEmailVerificationUseCase.java
@@ -6,7 +6,7 @@ import com.bamdoliro.maru.infrastructure.persistence.user.EmailVerificationRepos
 import com.bamdoliro.maru.shared.annotation.UseCase;
 import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
-import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.ITemplateEngine;
 import org.thymeleaf.context.Context;
 
 import java.io.UnsupportedEncodingException;
@@ -17,11 +17,10 @@ public class SendEmailVerificationUseCase {
 
     private final EmailVerificationRepository emailVerificationRepository;
     private final SendEmailService sendEmailService;
-    private final TemplateEngine templateEngine;
+    private final ITemplateEngine templateEngine;
 
     public void execute(String email) throws MessagingException, UnsupportedEncodingException {
-        EmailVerification verification = emailVerificationRepository.save(
-                new EmailVerification(email));
+        EmailVerification verification = emailVerificationRepository.save(new EmailVerification(email));
 
         sendEmailService.execute(
                 email,

--- a/src/main/java/com/bamdoliro/maru/application/user/SendEmailVerificationUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/user/SendEmailVerificationUseCase.java
@@ -1,0 +1,38 @@
+package com.bamdoliro.maru.application.user;
+
+import com.bamdoliro.maru.domain.user.domain.EmailVerification;
+import com.bamdoliro.maru.infrastructure.mail.SendEmailService;
+import com.bamdoliro.maru.infrastructure.persistence.user.EmailVerificationRepository;
+import com.bamdoliro.maru.shared.annotation.UseCase;
+import jakarta.mail.MessagingException;
+import lombok.RequiredArgsConstructor;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+import java.io.UnsupportedEncodingException;
+
+@RequiredArgsConstructor
+@UseCase
+public class SendEmailVerificationUseCase {
+
+    private final EmailVerificationRepository emailVerificationRepository;
+    private final SendEmailService sendEmailService;
+    private final TemplateEngine templateEngine;
+
+    public void execute(String email) throws MessagingException, UnsupportedEncodingException {
+        EmailVerification verification = emailVerificationRepository.save(
+                new EmailVerification(email));
+
+        sendEmailService.execute(
+                email,
+                "[부산소프트웨어마이스터고] 이메일 인증을 요청했습니다.",
+                setContext(verification.getCode())
+        );
+    }
+
+    private String setContext(String code) {
+        Context context = new Context();
+        context.setVariable("code", code);
+        return templateEngine.process("email-verification", context);
+    }
+}

--- a/src/main/java/com/bamdoliro/maru/application/user/SignUpUserUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/user/SignUpUserUseCase.java
@@ -1,7 +1,10 @@
 package com.bamdoliro.maru.application.user;
 
+import com.bamdoliro.maru.domain.user.domain.EmailVerification;
 import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.domain.user.exception.UserAlreadyExistsException;
+import com.bamdoliro.maru.domain.user.exception.VerifyingHasFailedException;
+import com.bamdoliro.maru.infrastructure.persistence.user.EmailVerificationRepository;
 import com.bamdoliro.maru.infrastructure.persistence.user.UserRepository;
 import com.bamdoliro.maru.presentation.user.dto.request.SignUpUserRequest;
 import com.bamdoliro.maru.shared.annotation.UseCase;
@@ -12,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @UseCase
 public class SignUpUserUseCase {
 
+    private final EmailVerificationRepository emailVerificationRepository;
     private final UserRepository userRepository;
 
     @Transactional
@@ -27,6 +31,13 @@ public class SignUpUserUseCase {
     }
 
     private void validate(SignUpUserRequest request) {
+        EmailVerification verification = emailVerificationRepository.findById(request.getEmail())
+                .orElseThrow(VerifyingHasFailedException::new);
+
+        if (!verification.getCode().equals(request.getCode())) {
+            throw new VerifyingHasFailedException();
+        }
+
         if (userRepository.existsByEmail(request.getEmail())) {
             throw new UserAlreadyExistsException();
         }

--- a/src/main/java/com/bamdoliro/maru/application/user/SignUpUserUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/user/SignUpUserUseCase.java
@@ -3,6 +3,7 @@ package com.bamdoliro.maru.application.user;
 import com.bamdoliro.maru.domain.user.domain.EmailVerification;
 import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.domain.user.exception.UserAlreadyExistsException;
+import com.bamdoliro.maru.domain.user.exception.VerificationCodeMismatchException;
 import com.bamdoliro.maru.domain.user.exception.VerifyingHasFailedException;
 import com.bamdoliro.maru.infrastructure.persistence.user.EmailVerificationRepository;
 import com.bamdoliro.maru.infrastructure.persistence.user.UserRepository;
@@ -35,7 +36,7 @@ public class SignUpUserUseCase {
                 .orElseThrow(VerifyingHasFailedException::new);
 
         if (!verification.getCode().equals(request.getCode())) {
-            throw new VerifyingHasFailedException();
+            throw new VerificationCodeMismatchException();
         }
 
         if (userRepository.existsByEmail(request.getEmail())) {

--- a/src/main/java/com/bamdoliro/maru/domain/user/domain/EmailVerification.java
+++ b/src/main/java/com/bamdoliro/maru/domain/user/domain/EmailVerification.java
@@ -1,0 +1,24 @@
+package com.bamdoliro.maru.domain.user.domain;
+
+import com.bamdoliro.maru.shared.util.RandomCodeUtil;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@RedisHash(value = "emailVerification", timeToLive = 60 * 5)
+public class EmailVerification {
+
+    @Id
+    private String email;
+
+    private String code;
+
+    public EmailVerification(String email) {
+        this.email = email;
+        this.code = RandomCodeUtil.generate(6);
+    }
+}

--- a/src/main/java/com/bamdoliro/maru/domain/user/exception/VerificationCodeMismatchException.java
+++ b/src/main/java/com/bamdoliro/maru/domain/user/exception/VerificationCodeMismatchException.java
@@ -1,0 +1,11 @@
+package com.bamdoliro.maru.domain.user.exception;
+
+import com.bamdoliro.maru.domain.user.exception.error.UserErrorProperty;
+import com.bamdoliro.maru.shared.error.MaruException;
+
+public class VerificationCodeMismatchException extends MaruException {
+
+    public VerificationCodeMismatchException() {
+        super(UserErrorProperty.VERIFICATION_CODE_MISMATCH);
+    }
+}

--- a/src/main/java/com/bamdoliro/maru/domain/user/exception/VerifyingHasFailedException.java
+++ b/src/main/java/com/bamdoliro/maru/domain/user/exception/VerifyingHasFailedException.java
@@ -1,0 +1,11 @@
+package com.bamdoliro.maru.domain.user.exception;
+
+import com.bamdoliro.maru.domain.user.exception.error.UserErrorProperty;
+import com.bamdoliro.maru.shared.error.MaruException;
+
+public class VerifyingHasFailedException extends MaruException {
+
+    public VerifyingHasFailedException() {
+        super(UserErrorProperty.VERIFYING_HAS_FAILED);
+    }
+}

--- a/src/main/java/com/bamdoliro/maru/domain/user/exception/error/UserErrorProperty.java
+++ b/src/main/java/com/bamdoliro/maru/domain/user/exception/error/UserErrorProperty.java
@@ -10,7 +10,9 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorProperty implements ErrorProperty {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자가 없습니다."),
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 가입한 사용자입니다."),
-    PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "비밀번호가 틀렸습니다.");
+    PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "비밀번호가 틀렸습니다."),
+    VERIFYING_HAS_FAILED(HttpStatus.UNAUTHORIZED, "이메일 인증을 실패했습니다."),
+    ;
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/bamdoliro/maru/domain/user/exception/error/UserErrorProperty.java
+++ b/src/main/java/com/bamdoliro/maru/domain/user/exception/error/UserErrorProperty.java
@@ -11,7 +11,8 @@ public enum UserErrorProperty implements ErrorProperty {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자가 없습니다."),
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 가입한 사용자입니다."),
     PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "비밀번호가 틀렸습니다."),
-    VERIFYING_HAS_FAILED(HttpStatus.UNAUTHORIZED, "이메일 인증을 실패했습니다."),
+    VERIFYING_HAS_FAILED(HttpStatus.UNAUTHORIZED, "이메일 인증이 실패했습니다."),
+    VERIFICATION_CODE_MISMATCH(HttpStatus.UNAUTHORIZED, "이메일 인증 코드가 틀렸습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/bamdoliro/maru/infrastructure/mail/SendEmailService.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/mail/SendEmailService.java
@@ -1,14 +1,12 @@
 package com.bamdoliro.maru.infrastructure.mail;
 
-import jakarta.mail.MessagingException;
+import com.bamdoliro.maru.infrastructure.mail.exception.FailedToSendMailException;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
-
-import java.io.UnsupportedEncodingException;
 
 @RequiredArgsConstructor
 @Service
@@ -19,15 +17,20 @@ public class SendEmailService {
     @Value("${spring.mail.username}")
     private String from;
 
-    public void execute(String to, String subject, String body) throws MessagingException, UnsupportedEncodingException {
-        MimeMessage message = mailSender.createMimeMessage();
+    public void execute(String to, String subject, String body) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
 
-        message.addRecipients(MimeMessage.RecipientType.TO, to);
-        message.setSubject(subject);
-        message.setText(body, "utf-8", "html");
+            message.addRecipients(MimeMessage.RecipientType.TO, to);
+            message.setSubject(subject);
+            message.setText(body, "utf-8", "html");
 
-        message.setFrom(new InternetAddress(from, "밤돌이로"));
+            message.setFrom(new InternetAddress(from, "밤돌이로"));
 
-        mailSender.send(message);
+            mailSender.send(message);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new FailedToSendMailException();
+        }
     }
 }

--- a/src/main/java/com/bamdoliro/maru/infrastructure/mail/SendEmailService.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/mail/SendEmailService.java
@@ -1,0 +1,33 @@
+package com.bamdoliro.maru.infrastructure.mail;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.io.UnsupportedEncodingException;
+
+@RequiredArgsConstructor
+@Service
+public class SendEmailService {
+
+    private final JavaMailSender mailSender;
+
+    @Value("${spring.mail.username}")
+    private String from;
+
+    public void execute(String to, String subject, String body) throws MessagingException, UnsupportedEncodingException {
+        MimeMessage message = mailSender.createMimeMessage();
+
+        message.addRecipients(MimeMessage.RecipientType.TO, to);
+        message.setSubject(subject);
+        message.setText(body, "utf-8", "html");
+
+        message.setFrom(new InternetAddress(from, "밤돌이로"));
+
+        mailSender.send(message);
+    }
+}

--- a/src/main/java/com/bamdoliro/maru/infrastructure/mail/SendEmailService.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/mail/SendEmailService.java
@@ -29,7 +29,6 @@ public class SendEmailService {
 
             mailSender.send(message);
         } catch (Exception e) {
-            e.printStackTrace();
             throw new FailedToSendMailException();
         }
     }

--- a/src/main/java/com/bamdoliro/maru/infrastructure/mail/exception/FailedToSendMailException.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/mail/exception/FailedToSendMailException.java
@@ -1,0 +1,11 @@
+package com.bamdoliro.maru.infrastructure.mail.exception;
+
+import com.bamdoliro.maru.infrastructure.mail.exception.error.MailErrorProperty;
+import com.bamdoliro.maru.shared.error.MaruException;
+
+public class FailedToSendMailException extends MaruException {
+
+    public FailedToSendMailException() {
+        super(MailErrorProperty.FAILED_TO_SEND);
+    }
+}

--- a/src/main/java/com/bamdoliro/maru/infrastructure/mail/exception/error/MailErrorProperty.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/mail/exception/error/MailErrorProperty.java
@@ -1,0 +1,15 @@
+package com.bamdoliro.maru.infrastructure.mail.exception.error;
+
+import com.bamdoliro.maru.shared.error.ErrorProperty;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MailErrorProperty implements ErrorProperty {
+    FAILED_TO_SEND(HttpStatus.INTERNAL_SERVER_ERROR, "메일 전송에 실패했습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/bamdoliro/maru/infrastructure/persistence/user/EmailVerificationRepository.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/persistence/user/EmailVerificationRepository.java
@@ -1,0 +1,11 @@
+package com.bamdoliro.maru.infrastructure.persistence.user;
+
+import com.bamdoliro.maru.domain.user.domain.EmailVerification;
+import org.springframework.data.keyvalue.repository.KeyValueRepository;
+
+import java.util.Optional;
+
+public interface EmailVerificationRepository extends KeyValueRepository<EmailVerification, String> {
+
+    Optional<EmailVerification> findById(String email);
+}

--- a/src/main/java/com/bamdoliro/maru/presentation/user/UserController.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/user/UserController.java
@@ -3,10 +3,11 @@ package com.bamdoliro.maru.presentation.user;
 import com.bamdoliro.maru.application.user.SendEmailVerificationUseCase;
 import com.bamdoliro.maru.application.user.SignUpUserUseCase;
 import com.bamdoliro.maru.presentation.user.dto.request.SignUpUserRequest;
-import jakarta.mail.MessagingException;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,9 +15,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.io.UnsupportedEncodingException;
-
 @RequiredArgsConstructor
+@Validated
 @RequestMapping("/user")
 @RestController
 public class UserController {
@@ -31,7 +31,11 @@ public class UserController {
     }
 
     @PostMapping("/verification")
-    public void sendEmailVerification(@RequestParam String email) throws MessagingException, UnsupportedEncodingException {
+    public void sendEmailVerification(
+            @Email(message = "올바른 형식의 이메일이어야 합니다.")
+            @RequestParam
+            String email
+    ) {
         sendEmailVerificationUseCase.execute(email);
     }
 }

--- a/src/main/java/com/bamdoliro/maru/presentation/user/UserController.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/user/UserController.java
@@ -5,8 +5,6 @@ import com.bamdoliro.maru.application.user.SignUpUserUseCase;
 import com.bamdoliro.maru.presentation.user.dto.request.SignUpUserRequest;
 import jakarta.mail.MessagingException;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,7 +26,7 @@ public class UserController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public void signUp(@RequestBody SignUpUserRequest request) {
+    public void signUp(@RequestBody @Valid SignUpUserRequest request) {
         signUpUserUseCase.execute(request);
     }
 

--- a/src/main/java/com/bamdoliro/maru/presentation/user/UserController.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/user/UserController.java
@@ -1,15 +1,22 @@
 package com.bamdoliro.maru.presentation.user;
 
+import com.bamdoliro.maru.application.user.SendEmailVerificationUseCase;
 import com.bamdoliro.maru.application.user.SignUpUserUseCase;
 import com.bamdoliro.maru.presentation.user.dto.request.SignUpUserRequest;
+import jakarta.mail.MessagingException;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.io.UnsupportedEncodingException;
 
 @RequiredArgsConstructor
 @RequestMapping("/user")
@@ -17,10 +24,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final SignUpUserUseCase signUpUserUseCase;
+    private final SendEmailVerificationUseCase sendEmailVerificationUseCase;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public void signUp(@RequestBody @Valid SignUpUserRequest request) {
+    public void signUp(@RequestBody SignUpUserRequest request) {
         signUpUserUseCase.execute(request);
+    }
+
+    @PostMapping("/verification")
+    public void sendEmailVerification(@RequestParam String email) throws MessagingException, UnsupportedEncodingException {
+        sendEmailVerificationUseCase.execute(email);
     }
 }

--- a/src/main/java/com/bamdoliro/maru/presentation/user/dto/request/SignUpUserRequest.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/user/dto/request/SignUpUserRequest.java
@@ -19,6 +19,10 @@ public class SignUpUserRequest {
     private String email;
 
     @NotBlank(message = "필수값입니다.")
+    @Size(min = 6, max = 6, message = "6글자여야 합니다.")
+    private String code;
+
+    @NotBlank(message = "필수값입니다.")
     @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[$@$!%*#?&])[A-Za-z\\d$@$!%*#?&]{8,}$",
             message = "비밀번호는 최소 하나의 문자, 숫자, 특수문자를 포함하며 8 글자 이상이어야 합니다.")
     private String password;

--- a/src/main/java/com/bamdoliro/maru/shared/config/properties/JwtProperties.java
+++ b/src/main/java/com/bamdoliro/maru/shared/config/properties/JwtProperties.java
@@ -3,8 +3,8 @@ package com.bamdoliro.maru.shared.config.properties;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
 
+@Setter
 @Getter
 @ConfigurationProperties("jwt")
 public class JwtProperties {

--- a/src/main/java/com/bamdoliro/maru/shared/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/bamdoliro/maru/shared/error/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.bamdoliro.maru.shared.error;
 
 import com.bamdoliro.maru.shared.response.ErrorResponse;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
@@ -10,7 +12,9 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @RestControllerAdvice
@@ -24,6 +28,19 @@ public class GlobalExceptionHandler {
 
         for (FieldError error : e.getFieldErrors()) {
             errorMap.put(error.getField(), error.getDefaultMessage());
+        }
+
+        return ResponseEntity
+                .status(GlobalErrorProperty.BAD_REQUEST.getStatus())
+                .body(new ErrorResponse(GlobalErrorProperty.BAD_REQUEST, errorMap));
+    }
+
+    @ExceptionHandler({ConstraintViolationException.class})
+    @ResponseStatus(value = HttpStatus.BAD_REQUEST)
+    public ResponseEntity<ErrorResponse> handleConstraintViolation(ConstraintViolationException e) {
+        Map<String, String> errorMap = new HashMap<>();
+        for (ConstraintViolation<?> violation : e.getConstraintViolations()) {
+            errorMap.put(violation.getPropertyPath().toString(), violation.getMessage());
         }
 
         return ResponseEntity

--- a/src/main/java/com/bamdoliro/maru/shared/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/bamdoliro/maru/shared/error/GlobalExceptionHandler.java
@@ -12,9 +12,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 @RestControllerAdvice

--- a/src/main/java/com/bamdoliro/maru/shared/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/bamdoliro/maru/shared/error/GlobalExceptionHandler.java
@@ -44,11 +44,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleMaruException(MaruException e) {
         return ResponseEntity
                 .status(e.getErrorProperty().getStatus())
-                .body(new ErrorResponse(e.getErrorProperty(), e.getMessage()));
+                .body(new ErrorResponse(e.getErrorProperty()));
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleException() {
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        e.printStackTrace();
         return ResponseEntity
                 .status(GlobalErrorProperty.INTERNAL_SERVER_ERROR.getStatus())
                 .body(new ErrorResponse(GlobalErrorProperty.INTERNAL_SERVER_ERROR));

--- a/src/main/java/com/bamdoliro/maru/shared/util/RandomCodeUtil.java
+++ b/src/main/java/com/bamdoliro/maru/shared/util/RandomCodeUtil.java
@@ -1,0 +1,10 @@
+package com.bamdoliro.maru.shared.util;
+
+import org.apache.commons.lang3.RandomStringUtils;
+
+public class RandomCodeUtil {
+
+    public static String generate(int count) {
+        return RandomStringUtils.randomAlphanumeric(count);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,19 @@ spring:
       password: ${REDIS_PASSWORD}
       port: 6379
 
+  mail:
+    host: ${MAIL_HOST}
+    port: ${MAIL_PORT}
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+
 jwt:
   refresh-expiration-time: 2592000000 # 30일
   access-expiration-time: 3600000 # 1시간

--- a/src/main/resources/templates/email-verification.html
+++ b/src/main/resources/templates/email-verification.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org" lang="en">
+<head>
+    <meta charset="UTF-8"/>
+    <link rel="stylesheet" as="style" crossorigin
+          href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.6/dist/web/static/pretendard.css"/>
+</head>
+<body style="margin:0;padding:0;width:100vw;height:100vh;">
+<div style="font-family: 'Pretendard';width:100%;height:100%;display:flex;justify-content:center;align-items:center;">
+<div style="width: 404px;">
+    <img style="height: 47px;" alt="logo"
+         src="https://user-images.githubusercontent.com/80656733/234810839-fdc293c0-1ba9-40ef-81b2-7ec55aac8624.png"/>
+    <h1 style="font-style:normal;font-weight:700;font-size:36px;line-height:140%;letter-spacing:0.25px;color:#21242C;margin-top:16px;">이메일 인증을 요청했습니다.</h1>
+    <p style="font-style:normal;font-weight:400;font-size:18px;line-height:160%;letter-spacing:-0.15px;color:#595B61;margin-top:8px;">아래 코드를 입력해주세요.<br>본인이 보낸 요청이 아니라면 해당 메일을 무시해주세요.</p>
+    <p th:text="${code}" style="width:100%;text-align:center;padding:8px 0;background:linear-gradient(0deg,rgba(255,255,255,0.9),rgba(255,255,255,0.9)),#257CFF;border-radius:8px;font-style:normal;font-weight:700;font-size:28px;line-height:39px;color:#21242C;margin-top:64px;"></p>
+</div>
+</div>
+</body>
+</html>

--- a/src/test/java/com/bamdoliro/maru/application/user/SendEmailVerificationUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/user/SendEmailVerificationUseCaseTest.java
@@ -10,15 +10,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.thymeleaf.ITemplateEngine;
-import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
-import org.thymeleaf.context.IContext;
 
 import java.io.UnsupportedEncodingException;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;

--- a/src/test/java/com/bamdoliro/maru/application/user/SendEmailVerificationUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/user/SendEmailVerificationUseCaseTest.java
@@ -1,0 +1,62 @@
+package com.bamdoliro.maru.application.user;
+
+import com.bamdoliro.maru.domain.user.domain.EmailVerification;
+import com.bamdoliro.maru.infrastructure.mail.SendEmailService;
+import com.bamdoliro.maru.infrastructure.persistence.user.EmailVerificationRepository;
+import com.bamdoliro.maru.shared.fixture.UserFixture;
+import jakarta.mail.MessagingException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.thymeleaf.ITemplateEngine;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.context.IContext;
+
+import java.io.UnsupportedEncodingException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class SendEmailVerificationUseCaseTest {
+
+    @InjectMocks
+    private SendEmailVerificationUseCase sendEmailVerificationUseCase;
+
+    @Mock
+    private SendEmailService sendEmailService;
+
+    @Mock
+    private EmailVerificationRepository emailVerificationRepository;
+
+    @Mock
+    private ITemplateEngine templateEngine;
+
+    @Test
+    void 유저가_이메일_인증을_요청한다() throws MessagingException, UnsupportedEncodingException {
+        // given
+        EmailVerification verification = UserFixture.createVerification();
+        given(emailVerificationRepository.save(any(EmailVerification.class))).willReturn(verification);
+        given(templateEngine.process(anyString(), any(Context.class))).willReturn("context");
+        willDoNothing().given(sendEmailService).execute(anyString(), anyString(), anyString());
+
+        // when
+        sendEmailVerificationUseCase.execute(verification.getEmail());
+
+        // then
+        verify(emailVerificationRepository, times(1)).save(any(EmailVerification.class));
+        verify(templateEngine, times(1)).process(anyString(), any(Context.class));
+        verify(sendEmailService, times(1)).execute(anyString(), anyString(), anyString());
+
+        assertNotNull(verification.getCode());
+    }
+}

--- a/src/test/java/com/bamdoliro/maru/application/user/SendEmailVerificationUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/user/SendEmailVerificationUseCaseTest.java
@@ -2,9 +2,9 @@ package com.bamdoliro.maru.application.user;
 
 import com.bamdoliro.maru.domain.user.domain.EmailVerification;
 import com.bamdoliro.maru.infrastructure.mail.SendEmailService;
+import com.bamdoliro.maru.infrastructure.mail.exception.FailedToSendMailException;
 import com.bamdoliro.maru.infrastructure.persistence.user.EmailVerificationRepository;
 import com.bamdoliro.maru.shared.fixture.UserFixture;
-import jakarta.mail.MessagingException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -13,15 +13,17 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.thymeleaf.ITemplateEngine;
 import org.thymeleaf.context.Context;
 
-import java.io.UnsupportedEncodingException;
-
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
 
 @ExtendWith(MockitoExtension.class)
 class SendEmailVerificationUseCaseTest {
@@ -30,30 +32,47 @@ class SendEmailVerificationUseCaseTest {
     private SendEmailVerificationUseCase sendEmailVerificationUseCase;
 
     @Mock
+    private ITemplateEngine templateEngine;
+
+    @Mock
     private SendEmailService sendEmailService;
 
     @Mock
     private EmailVerificationRepository emailVerificationRepository;
 
-    @Mock
-    private ITemplateEngine templateEngine;
 
     @Test
-    void 유저가_이메일_인증을_요청한다() throws MessagingException, UnsupportedEncodingException {
+    void 유저가_이메일_인증을_요청한다() {
         // given
         EmailVerification verification = UserFixture.createVerification();
-        given(emailVerificationRepository.save(any(EmailVerification.class))).willReturn(verification);
         given(templateEngine.process(anyString(), any(Context.class))).willReturn("context");
         willDoNothing().given(sendEmailService).execute(anyString(), anyString(), anyString());
+        given(emailVerificationRepository.save(any(EmailVerification.class))).willReturn(verification);
 
         // when
         sendEmailVerificationUseCase.execute(verification.getEmail());
 
         // then
-        verify(emailVerificationRepository, times(1)).save(any(EmailVerification.class));
         verify(templateEngine, times(1)).process(anyString(), any(Context.class));
         verify(sendEmailService, times(1)).execute(anyString(), anyString(), anyString());
+        verify(emailVerificationRepository, times(1)).save(any(EmailVerification.class));
 
         assertNotNull(verification.getCode());
+    }
+
+    @Test
+    void 이메일_전송이_실패한다() {
+        // given
+        EmailVerification verification = UserFixture.createVerification();
+        given(templateEngine.process(anyString(), any(Context.class))).willReturn("context");
+        doThrow(new FailedToSendMailException()).when(sendEmailService).execute(anyString(), anyString(), anyString());
+
+        // when and then
+        assertThrows(FailedToSendMailException.class,
+                () -> sendEmailVerificationUseCase.execute(verification.getEmail()));
+
+        verify(templateEngine, times(1)).process(anyString(), any(Context.class));
+        verify(sendEmailService, times(1)).execute(anyString(), anyString(), anyString());
+        verify(emailVerificationRepository, never()).save(any(EmailVerification.class));
     }
 }

--- a/src/test/java/com/bamdoliro/maru/application/user/SignUpUserUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/user/SignUpUserUseCaseTest.java
@@ -1,7 +1,11 @@
 package com.bamdoliro.maru.application.user;
 
+import com.bamdoliro.maru.domain.user.domain.EmailVerification;
 import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.domain.user.exception.UserAlreadyExistsException;
+import com.bamdoliro.maru.domain.user.exception.VerificationCodeMismatchException;
+import com.bamdoliro.maru.domain.user.exception.VerifyingHasFailedException;
+import com.bamdoliro.maru.infrastructure.persistence.user.EmailVerificationRepository;
 import com.bamdoliro.maru.infrastructure.persistence.user.UserRepository;
 import com.bamdoliro.maru.presentation.user.dto.request.SignUpUserRequest;
 import com.bamdoliro.maru.shared.fixture.UserFixture;
@@ -12,6 +16,8 @@ import org.mockito.InjectMocks;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -27,17 +33,22 @@ class SignUpUserUseCaseTest {
     private SignUpUserUseCase signUpUserUseCase;
 
     @Mock
+    private EmailVerificationRepository emailVerificationRepository;
+
+    @Mock
     private UserRepository userRepository;
 
     @Test
     void 유저를_생성한다() {
         // given
         User user = UserFixture.createUser();
-        SignUpUserRequest request = new SignUpUserRequest(user.getEmail(), "비밀번호");
+        EmailVerification verification = UserFixture.createVerification();
+        SignUpUserRequest request = new SignUpUserRequest(user.getEmail(), verification.getCode(), "비밀번호");
         ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
 
-        given(userRepository.save(any(User.class))).willReturn(user);
+        given(emailVerificationRepository.findById(request.getEmail())).willReturn(Optional.of(verification));
         given(userRepository.existsByEmail(request.getEmail())).willReturn(false);
+        given(userRepository.save(any(User.class))).willReturn(user);
 
         // when
         signUpUserUseCase.execute(request);
@@ -50,11 +61,45 @@ class SignUpUserUseCaseTest {
     }
 
     @Test
+    void 이메일_인증을_요청하지_않았거나_만료되었다면_에러가_발생한다() {
+        // given
+        SignUpUserRequest request = new SignUpUserRequest("이메일", "ABC123", "비밀번호");
+
+        given(emailVerificationRepository.findById(request.getEmail())).willReturn(Optional.empty());
+
+        // when and then
+        assertThrows(VerifyingHasFailedException.class,
+                () -> signUpUserUseCase.execute(request));
+
+        verify(userRepository, never()).existsByEmail(any());
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void 이메일_인증_코드가_틀렸다면_에러가_발생한다() {
+        // given
+        User user = UserFixture.createUser();
+        EmailVerification verification = UserFixture.createVerification();
+        SignUpUserRequest request = new SignUpUserRequest(user.getEmail(), "다른코드같을수가없는코드", "비밀번호");
+
+        given(emailVerificationRepository.findById(request.getEmail())).willReturn(Optional.of(verification));
+
+        // when and then
+        assertThrows(VerificationCodeMismatchException.class,
+                () -> signUpUserUseCase.execute(request));
+
+        verify(userRepository, never()).existsByEmail(any());
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
     void 이미_유저가_있다면_에러가_발생한다() {
         // given
         User user = UserFixture.createUser();
-        SignUpUserRequest request = new SignUpUserRequest(user.getEmail(), "비밀번호");
+        EmailVerification verification = UserFixture.createVerification();
+        SignUpUserRequest request = new SignUpUserRequest(user.getEmail(), verification.getCode(), "비밀번호");
 
+        given(emailVerificationRepository.findById(request.getEmail())).willReturn(Optional.of(verification));
         given(userRepository.existsByEmail(request.getEmail())).willReturn(true);
 
         // when and then

--- a/src/test/java/com/bamdoliro/maru/application/user/SignUpUserUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/user/SignUpUserUseCaseTest.java
@@ -9,17 +9,17 @@ import com.bamdoliro.maru.infrastructure.persistence.user.EmailVerificationRepos
 import com.bamdoliro.maru.infrastructure.persistence.user.UserRepository;
 import com.bamdoliro.maru.presentation.user.dto.request.SignUpUserRequest;
 import com.bamdoliro.maru.shared.fixture.UserFixture;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;

--- a/src/test/java/com/bamdoliro/maru/infrastructure/mail/SendEmailServiceTest.java
+++ b/src/test/java/com/bamdoliro/maru/infrastructure/mail/SendEmailServiceTest.java
@@ -1,13 +1,16 @@
 package com.bamdoliro.maru.infrastructure.mail;
 
+import com.bamdoliro.maru.infrastructure.mail.exception.FailedToSendMailException;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 @Disabled
 @SpringBootTest
-class SendEmailServiceTestVerification {
+class SendEmailServiceTest {
 
     @Autowired
     private SendEmailService sendEmailService;
@@ -15,5 +18,11 @@ class SendEmailServiceTestVerification {
     @Test
     void 메일을_전송한다() throws Exception {
         sendEmailService.execute("gimhanuly@gmail.com", "테스트 메일", "테스트 메일입니다.");
+    }
+
+    @Test
+    void 없는_주소로_메일을_전송하면_에러가_발생한다() throws Exception {
+        assertThrows(FailedToSendMailException.class,
+                () -> sendEmailService.execute("누가봐도@없는.이메일", "어차피안감", "진심임"));
     }
 }

--- a/src/test/java/com/bamdoliro/maru/infrastructure/mail/SendEmailServiceTestVerification.java
+++ b/src/test/java/com/bamdoliro/maru/infrastructure/mail/SendEmailServiceTestVerification.java
@@ -1,0 +1,19 @@
+package com.bamdoliro.maru.infrastructure.mail;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@Disabled
+@SpringBootTest
+class SendEmailServiceTestVerification {
+
+    @Autowired
+    private SendEmailService sendEmailService;
+
+    @Test
+    void 메일을_전송한다() throws Exception {
+        sendEmailService.execute("gimhanuly@gmail.com", "테스트 메일", "테스트 메일입니다.");
+    }
+}

--- a/src/test/java/com/bamdoliro/maru/presentation/user/UserControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/presentation/user/UserControllerTest.java
@@ -1,6 +1,7 @@
 package com.bamdoliro.maru.presentation.user;
 
 import com.bamdoliro.maru.domain.user.exception.UserAlreadyExistsException;
+import com.bamdoliro.maru.domain.user.exception.VerifyingHasFailedException;
 import com.bamdoliro.maru.domain.user.exception.error.UserErrorProperty;
 import com.bamdoliro.maru.presentation.user.dto.request.SignUpUserRequest;
 import com.bamdoliro.maru.shared.util.RestDocsTestSupport;
@@ -21,7 +22,7 @@ class UserControllerTest extends RestDocsTestSupport {
     @Test
     void 유저를_생성한다() throws Exception {
         willDoNothing().given(signUpUserUseCase).execute(any(SignUpUserRequest.class));
-        SignUpUserRequest request = new SignUpUserRequest("maru@bamdoliro.com", "password123$");
+        SignUpUserRequest request = new SignUpUserRequest("maru@bamdoliro.com", "ABC123", "password123$");
 
         mockMvc.perform(post("/user")
                         .accept(MediaType.APPLICATION_JSON)
@@ -36,6 +37,9 @@ class UserControllerTest extends RestDocsTestSupport {
                                 fieldWithPath("email")
                                         .type(JsonFieldType.STRING)
                                         .description("이메일"),
+                                fieldWithPath("code")
+                                        .type(JsonFieldType.STRING)
+                                        .description("이메일 인증 코드"),
                                 fieldWithPath("password")
                                         .type(JsonFieldType.STRING)
                                         .description("최소 8 자, 최소 하나의 문자, 하나의 숫자 및 하나의 특수 문자를 포함하는 비밀번호")
@@ -43,12 +47,25 @@ class UserControllerTest extends RestDocsTestSupport {
                 ));
     }
 
+    @Test
+    void 유저를_생성할_때_인증되지_않은_이메일이라면_에러가_발생한다() throws Exception {
+        doThrow(new VerifyingHasFailedException()).when(signUpUserUseCase).execute(any(SignUpUserRequest.class));
+        SignUpUserRequest request = new SignUpUserRequest("maru@bamdoliro.com", "ABC123", "password123$");
+
+        mockMvc.perform(post("/user")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(request))
+                )
+                .andExpect(status().isUnauthorized())
+                .andDo(restDocs.document());
+    }
 
     @Test
     void 유저를_생성할_때_이미_유저가_있다면_에러가_발생한다() throws Exception {
         doThrow(new UserAlreadyExistsException())
                 .when(signUpUserUseCase).execute(any(SignUpUserRequest.class));
-        SignUpUserRequest request = new SignUpUserRequest("maru@bamdoliro.com", "password123$");
+        SignUpUserRequest request = new SignUpUserRequest("maru@bamdoliro.com", "ABC123", "password123$");
 
         mockMvc.perform(post("/user")
                         .accept(MediaType.APPLICATION_JSON)
@@ -64,7 +81,7 @@ class UserControllerTest extends RestDocsTestSupport {
     @Test
     void 유저를_생성할_때_잘못된_형식의_요청을_보내면_에러가_발생한다() throws Exception {
         willDoNothing().given(signUpUserUseCase).execute(any(SignUpUserRequest.class));
-        SignUpUserRequest request = new SignUpUserRequest("bamdoliro", "p$");
+        SignUpUserRequest request = new SignUpUserRequest("bamdoliro", "ABC13", "p$");
 
         mockMvc.perform(post("/user")
                         .accept(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/bamdoliro/maru/shared/fixture/UserFixture.java
+++ b/src/test/java/com/bamdoliro/maru/shared/fixture/UserFixture.java
@@ -1,10 +1,15 @@
 package com.bamdoliro.maru.shared.fixture;
 
+import com.bamdoliro.maru.domain.user.domain.EmailVerification;
 import com.bamdoliro.maru.domain.user.domain.User;
 
 public class UserFixture {
 
     public static User createUser() {
         return new User("maru@bamdoliro.com", "비밀번호");
+    }
+
+    public static EmailVerification createVerification() {
+        return new EmailVerification("maru@bamdoliro.com");
     }
 }

--- a/src/test/java/com/bamdoliro/maru/shared/util/ControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/shared/util/ControllerTest.java
@@ -2,8 +2,10 @@ package com.bamdoliro.maru.shared.util;
 
 import com.bamdoliro.maru.application.auth.LogInUseCase;
 import com.bamdoliro.maru.application.auth.RefreshTokenUseCase;
+import com.bamdoliro.maru.application.user.SendEmailVerificationUseCase;
 import com.bamdoliro.maru.application.user.SignUpUserUseCase;
 import com.bamdoliro.maru.domain.auth.service.TokenService;
+import com.bamdoliro.maru.infrastructure.mail.SendEmailService;
 import com.bamdoliro.maru.presentation.auth.AuthController;
 import com.bamdoliro.maru.shared.config.properties.JwtProperties;
 import com.bamdoliro.maru.shared.security.SecurityConfig;
@@ -44,12 +46,19 @@ public abstract class ControllerTest {
     @MockBean
     protected RefreshTokenUseCase refreshTokenUseCase;
 
+    @MockBean
+    protected SendEmailVerificationUseCase sendEmailVerificationUseCase;
+
 
     @MockBean
     protected TokenService tokenService;
 
     @MockBean
     protected AuthDetailsService authDetailsService;
+
+
+    @MockBean
+    protected SendEmailService sendEmailService;
 
 
     @MockBean


### PR DESCRIPTION
## 📄 Summary
> 이메일 인증 기능 개발


<br>

## 🔨 Tasks
- 이메일 인증 요청 API 추가
- 회원가입에 이메일 인증 코드 검증 로직 추가
- 관련 테스트
- 관련 문서 작성


<br>

## 🙋🏻 More
### 이메일 인증 과정
1. 유저가 이메일 인증을 요청한다.
2. 서버에서 인증 문자열을 이메일로 전송한다.
3. 유저는 회원가입할 ㄸㅐ 인증코드를 같이 입력한다