### PR TITLE
원서 검토

### DIFF
--- a/src/docs/asciidoc/form.adoc
+++ b/src/docs/asciidoc/form.adoc
@@ -69,3 +69,20 @@ include::{snippets}/form-controller-test/원서를_반려한다/http-response.ad
 
 ===== 해당하는 원서가 없는 경우
 include::{snippets}/form-controller-test/원서를_반려할_때_원서가_없으면_에러가_발생한다/http-response.adoc[]
+
+=== 검토해야 하는 원서 조회
+어드민은 검토해야 하는 원서를 조회할 수 있습니다.
+
+==== 요청 형식
+
+===== Request Header
+include::{snippets}/form-controller-test/검토해야_하는_원서를_조회한다/request-headers.adoc[]
+
+==== 요청
+include::{snippets}/form-controller-test/검토해야_하는_원서를_조회한다/http-request.adoc[]
+
+===== 정상 응답
+include::{snippets}/form-controller-test/검토해야_하는_원서를_조회한다/http-response.adoc[]
+
+===== 검토해야 하는 원서가 없는 경우
+include::{snippets}/form-controller-test/검토해야_하는_원서가_없으면_빈_리스트를_반환한다/http-response.adoc[]

--- a/src/docs/asciidoc/form.adoc
+++ b/src/docs/asciidoc/form.adoc
@@ -27,3 +27,45 @@ include::{snippets}/form-controller-test/원서를_접수할_때_이미_접수�
 
 ===== 요청 형식이 틀린 경우
 include::{snippets}/form-controller-test/원서를_접수할_때_잘못된_형식의_요청을_보내면_에러가_발생한다/http-response.adoc[]
+
+=== 원서 승인
+어드민은 원서를 승인할 수 있습니다.
+
+==== 요청 형식
+
+===== Request Header
+include::{snippets}/form-controller-test/원서를_승인한다/request-headers.adoc[]
+
+====== Path Parameter
+include::{snippets}/form-controller-test/원서를_승인한다/path-parameters.adoc[]
+
+==== 요청
+include::{snippets}/form-controller-test/원서를_승인한다/http-request.adoc[]
+
+==== 응답
+===== 정상 응답
+include::{snippets}/form-controller-test/원서를_승인한다/http-response.adoc[]
+
+===== 해당하는 원서가 없는 경우
+include::{snippets}/form-controller-test/원서를_승인할_때_원서가_없으면_에러가_발생한다/http-response.adoc[]
+
+=== 원서 반려
+어드민은 원서를 반려할 수 있습니다.
+
+==== 요청 형식
+
+===== Request Header
+include::{snippets}/form-controller-test/원서를_반려한다/request-headers.adoc[]
+
+====== Path Parameter
+include::{snippets}/form-controller-test/원서를_반려한다/path-parameters.adoc[]
+
+==== 요청
+include::{snippets}/form-controller-test/원서를_반려한다/http-request.adoc[]
+
+==== 응답
+===== 정상 응답
+include::{snippets}/form-controller-test/원서를_반려한다/http-response.adoc[]
+
+===== 해당하는 원서가 없는 경우
+include::{snippets}/form-controller-test/원서를_반려할_때_원서가_없으면_에러가_발생한다/http-response.adoc[]

--- a/src/main/java/com/bamdoliro/maru/application/form/ApproveFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/ApproveFormUseCase.java
@@ -1,7 +1,7 @@
 package com.bamdoliro.maru.application.form;
 
 import com.bamdoliro.maru.domain.form.domain.Form;
-import com.bamdoliro.maru.domain.form.facade.FormFacade;
+import com.bamdoliro.maru.domain.form.service.FormFacade;
 import com.bamdoliro.maru.shared.annotation.UseCase;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/bamdoliro/maru/application/form/ApproveFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/ApproveFormUseCase.java
@@ -1,0 +1,18 @@
+package com.bamdoliro.maru.application.form;
+
+import com.bamdoliro.maru.domain.form.domain.Form;
+import com.bamdoliro.maru.domain.form.facade.FormFacade;
+import com.bamdoliro.maru.shared.annotation.UseCase;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@UseCase
+public class ApproveFormUseCase {
+
+    private final FormFacade formFacade;
+
+    public void execute(Long id) {
+        Form form = formFacade.getForm(id);
+        form.approve();
+    }
+}

--- a/src/main/java/com/bamdoliro/maru/application/form/QuerySubmittedFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/QuerySubmittedFormUseCase.java
@@ -1,0 +1,25 @@
+package com.bamdoliro.maru.application.form;
+
+import com.bamdoliro.maru.domain.form.domain.type.FormStatus;
+import com.bamdoliro.maru.infrastructure.persistence.form.FormRepository;
+import com.bamdoliro.maru.presentation.form.dto.response.FormResponse;
+import com.bamdoliro.maru.shared.annotation.UseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@UseCase
+public class QuerySubmittedFormUseCase {
+
+    private final FormRepository formRepository;
+
+    @Transactional(readOnly = true)
+    public List<FormResponse> execute() {
+        return formRepository.findByStatus(FormStatus.SUBMITTED)
+                .stream()
+                .map(FormResponse::new)
+                .toList();
+    }
+}

--- a/src/main/java/com/bamdoliro/maru/application/form/RejectFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/RejectFormUseCase.java
@@ -1,7 +1,7 @@
 package com.bamdoliro.maru.application.form;
 
 import com.bamdoliro.maru.domain.form.domain.Form;
-import com.bamdoliro.maru.domain.form.facade.FormFacade;
+import com.bamdoliro.maru.domain.form.service.FormFacade;
 import com.bamdoliro.maru.shared.annotation.UseCase;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/bamdoliro/maru/application/form/RejectFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/RejectFormUseCase.java
@@ -1,0 +1,18 @@
+package com.bamdoliro.maru.application.form;
+
+import com.bamdoliro.maru.domain.form.domain.Form;
+import com.bamdoliro.maru.domain.form.facade.FormFacade;
+import com.bamdoliro.maru.shared.annotation.UseCase;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@UseCase
+public class RejectFormUseCase {
+
+    private final FormFacade formFacade;
+
+    public void execute(Long id) {
+        Form form = formFacade.getForm(id);
+        form.reject();
+    }
+}

--- a/src/main/java/com/bamdoliro/maru/application/user/SignUpUserUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/user/SignUpUserUseCase.java
@@ -2,6 +2,7 @@ package com.bamdoliro.maru.application.user;
 
 import com.bamdoliro.maru.domain.user.domain.EmailVerification;
 import com.bamdoliro.maru.domain.user.domain.User;
+import com.bamdoliro.maru.domain.user.domain.type.Authority;
 import com.bamdoliro.maru.domain.user.exception.UserAlreadyExistsException;
 import com.bamdoliro.maru.domain.user.exception.VerificationCodeMismatchException;
 import com.bamdoliro.maru.domain.user.exception.VerifyingHasFailedException;
@@ -27,6 +28,7 @@ public class SignUpUserUseCase {
                 User.builder()
                         .email(request.getEmail())
                         .password(request.getPassword())
+                        .authority(Authority.ROLE_USER)
                         .build()
         );
     }

--- a/src/main/java/com/bamdoliro/maru/domain/form/domain/Form.java
+++ b/src/main/java/com/bamdoliro/maru/domain/form/domain/Form.java
@@ -87,5 +87,13 @@ public class Form extends BaseTimeEntity {
     public void updateScore(Score score) {
         this.score = score;
     }
+
+    public void approve() {
+        this.status = FormStatus.APPROVED;
+    }
+
+    public void reject() {
+        this.status = FormStatus.REJECTED;
+    }
 }
 

--- a/src/main/java/com/bamdoliro/maru/domain/form/exception/FormNotFoundException.java
+++ b/src/main/java/com/bamdoliro/maru/domain/form/exception/FormNotFoundException.java
@@ -1,0 +1,11 @@
+package com.bamdoliro.maru.domain.form.exception;
+
+import com.bamdoliro.maru.domain.form.exception.error.FormErrorProperty;
+import com.bamdoliro.maru.shared.error.MaruException;
+
+public class FormNotFoundException extends MaruException {
+
+    public FormNotFoundException() {
+        super(FormErrorProperty.FORM_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/bamdoliro/maru/domain/form/exception/error/FormErrorProperty.java
+++ b/src/main/java/com/bamdoliro/maru/domain/form/exception/error/FormErrorProperty.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum FormErrorProperty implements ErrorProperty {
 
+    FORM_NOT_FOUND(HttpStatus.NOT_FOUND, "원서를 찾을 수 없습니다."),
     FORM_ALREADY_SUBMITTED(HttpStatus.CONFLICT, "원서는 한 번만 제출할 수 있습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/bamdoliro/maru/domain/form/facade/FormFacade.java
+++ b/src/main/java/com/bamdoliro/maru/domain/form/facade/FormFacade.java
@@ -1,0 +1,19 @@
+package com.bamdoliro.maru.domain.form.facade;
+
+import com.bamdoliro.maru.domain.form.domain.Form;
+import com.bamdoliro.maru.domain.form.exception.FormNotFoundException;
+import com.bamdoliro.maru.infrastructure.persistence.form.FormRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class FormFacade {
+
+    private final FormRepository formRepository;
+
+    public Form getForm(Long id) {
+        return formRepository.findById(id)
+                .orElseThrow(FormNotFoundException::new);
+    }
+}

--- a/src/main/java/com/bamdoliro/maru/domain/form/service/FormFacade.java
+++ b/src/main/java/com/bamdoliro/maru/domain/form/service/FormFacade.java
@@ -1,4 +1,4 @@
-package com.bamdoliro.maru.domain.form.facade;
+package com.bamdoliro.maru.domain.form.service;
 
 import com.bamdoliro.maru.domain.form.domain.Form;
 import com.bamdoliro.maru.domain.form.exception.FormNotFoundException;

--- a/src/main/java/com/bamdoliro/maru/domain/user/domain/User.java
+++ b/src/main/java/com/bamdoliro/maru/domain/user/domain/User.java
@@ -40,9 +40,9 @@ public class User extends BaseTimeEntity {
     private Authority authority;
 
     @Builder
-    public User(String email, String password) {
+    public User(String email, String password, Authority authority) {
         this.email = email;
         this.password = new Password(PasswordUtil.encode(password));
-        this.authority = Authority.ROLE_USER;
+        this.authority = authority;
     }
 }

--- a/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepository.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepository.java
@@ -1,9 +1,13 @@
 package com.bamdoliro.maru.infrastructure.persistence.form;
 
 import com.bamdoliro.maru.domain.form.domain.Form;
+import com.bamdoliro.maru.domain.form.domain.type.FormStatus;
 import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
 
 public interface FormRepository extends CrudRepository<Form, Long> {
 
     boolean existsByUserId(Long userId);
+    List<Form> findByStatus(FormStatus status);
 }

--- a/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
@@ -1,10 +1,15 @@
 package com.bamdoliro.maru.presentation.form;
 
+import com.bamdoliro.maru.application.form.ApproveFormUseCase;
+import com.bamdoliro.maru.application.form.RejectFormUseCase;
 import com.bamdoliro.maru.application.form.SubmitFormUseCase;
 import com.bamdoliro.maru.presentation.form.dto.request.FormRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,10 +22,26 @@ import org.springframework.web.bind.annotation.RestController;
 public class FormController {
 
     private final SubmitFormUseCase submitFormUseCase;
+    private final ApproveFormUseCase approveFormUseCase;
+    private final RejectFormUseCase rejectFormUseCase;
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
     public void submitForm(@RequestBody @Valid FormRequest request) {
         submitFormUseCase.execute(request);
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PatchMapping("/{form-id}/approve")
+    public void approveForm(@PathVariable(name = "form-id") Long formId) {
+        approveFormUseCase.execute(formId);
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PatchMapping("/{form-id}/reject")
+    public void rejectForm(@PathVariable(name = "form-id") Long formId) {
+        rejectFormUseCase.execute(formId);
     }
 }

--- a/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
@@ -6,7 +6,6 @@ import com.bamdoliro.maru.application.form.RejectFormUseCase;
 import com.bamdoliro.maru.application.form.SubmitFormUseCase;
 import com.bamdoliro.maru.presentation.form.dto.request.FormRequest;
 import com.bamdoliro.maru.presentation.form.dto.response.FormResponse;
-import com.bamdoliro.maru.shared.response.CommonResponse;
 import com.bamdoliro.maru.shared.response.ListCommonResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -52,8 +51,8 @@ public class FormController {
     }
 
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @GetMapping("/submitted")
-    public ListCommonResponse<FormResponse> getSubmittedForms() {
+    @GetMapping("/review")
+    public ListCommonResponse<FormResponse> getSubmittedFormList() {
         return ListCommonResponse.ok(
                 querySubmittedFormUseCase.execute()
         );

--- a/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
@@ -1,13 +1,18 @@
 package com.bamdoliro.maru.presentation.form;
 
 import com.bamdoliro.maru.application.form.ApproveFormUseCase;
+import com.bamdoliro.maru.application.form.QuerySubmittedFormUseCase;
 import com.bamdoliro.maru.application.form.RejectFormUseCase;
 import com.bamdoliro.maru.application.form.SubmitFormUseCase;
 import com.bamdoliro.maru.presentation.form.dto.request.FormRequest;
+import com.bamdoliro.maru.presentation.form.dto.response.FormResponse;
+import com.bamdoliro.maru.shared.response.CommonResponse;
+import com.bamdoliro.maru.shared.response.ListCommonResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -24,6 +29,7 @@ public class FormController {
     private final SubmitFormUseCase submitFormUseCase;
     private final ApproveFormUseCase approveFormUseCase;
     private final RejectFormUseCase rejectFormUseCase;
+    private final QuerySubmittedFormUseCase querySubmittedFormUseCase;
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
@@ -43,5 +49,13 @@ public class FormController {
     @PatchMapping("/{form-id}/reject")
     public void rejectForm(@PathVariable(name = "form-id") Long formId) {
         rejectFormUseCase.execute(formId);
+    }
+
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/submitted")
+    public ListCommonResponse<FormResponse> getSubmittedForms() {
+        return ListCommonResponse.ok(
+                querySubmittedFormUseCase.execute()
+        );
     }
 }

--- a/src/main/java/com/bamdoliro/maru/presentation/form/dto/response/FormResponse.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/form/dto/response/FormResponse.java
@@ -1,0 +1,20 @@
+package com.bamdoliro.maru.presentation.form.dto.response;
+
+
+import com.bamdoliro.maru.domain.form.domain.Form;
+import com.bamdoliro.maru.domain.form.domain.type.FormStatus;
+import lombok.Getter;
+
+@Getter
+public class FormResponse {
+
+    private Long id;
+    private String name;
+    private FormStatus status;
+
+    public FormResponse(Form form) {
+        this.id = form.getId();
+        this.name = form.getApplicant().getName();
+        this.status = form.getStatus();
+    }
+}

--- a/src/main/java/com/bamdoliro/maru/presentation/form/dto/response/FormResponse.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/form/dto/response/FormResponse.java
@@ -3,9 +3,11 @@ package com.bamdoliro.maru.presentation.form.dto.response;
 
 import com.bamdoliro.maru.domain.form.domain.Form;
 import com.bamdoliro.maru.domain.form.domain.type.FormStatus;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class FormResponse {
 
     private Long id;

--- a/src/test/java/com/bamdoliro/maru/application/form/ApproveFormUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/ApproveFormUseCaseTest.java
@@ -1,0 +1,54 @@
+package com.bamdoliro.maru.application.form;
+
+import com.bamdoliro.maru.domain.form.domain.Form;
+import com.bamdoliro.maru.domain.form.domain.type.FormStatus;
+import com.bamdoliro.maru.domain.form.domain.type.FormType;
+import com.bamdoliro.maru.domain.form.exception.FormNotFoundException;
+import com.bamdoliro.maru.domain.form.service.FormFacade;
+import com.bamdoliro.maru.shared.fixture.FormFixture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ApproveFormUseCaseTest {
+
+    @InjectMocks
+    private ApproveFormUseCase approveFormUseCase;
+
+    @Mock
+    private FormFacade formFacade;
+
+    @Test
+    void 원서를_승인한다() {
+        // given
+        Form form = FormFixture.createForm(FormType.REGULAR);
+        given(formFacade.getForm(form.getId())).willReturn(form);
+
+        // when
+        approveFormUseCase.execute(form.getId());
+
+        // then
+        verify(formFacade).getForm(form.getId());
+        assertEquals(form.getStatus(), FormStatus.APPROVED);
+    }
+
+    @Test
+    void 원서를_승인할_때_원서가_없으면_에러가_발생한다() {
+        // given
+        Form form = FormFixture.createForm(FormType.REGULAR);
+        willThrow(new FormNotFoundException()).given(formFacade).getForm(form.getId());
+        
+        // when and then
+        assertThrows(FormNotFoundException.class, () -> approveFormUseCase.execute(form.getId()));
+        assertEquals(form.getStatus(), FormStatus.SUBMITTED);
+    }
+}

--- a/src/test/java/com/bamdoliro/maru/application/form/QuerySubmittedFormUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/QuerySubmittedFormUseCaseTest.java
@@ -1,0 +1,65 @@
+package com.bamdoliro.maru.application.form;
+
+import com.bamdoliro.maru.domain.form.domain.Form;
+import com.bamdoliro.maru.domain.form.domain.type.FormStatus;
+import com.bamdoliro.maru.domain.form.domain.type.FormType;
+import com.bamdoliro.maru.infrastructure.persistence.form.FormRepository;
+import com.bamdoliro.maru.presentation.form.dto.response.FormResponse;
+import com.bamdoliro.maru.shared.fixture.FormFixture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class QuerySubmittedFormUseCaseTest {
+
+    @InjectMocks
+    private QuerySubmittedFormUseCase querySubmittedFormUseCase;
+
+    @Mock
+    private FormRepository formRepository;
+
+    @Test
+    void 검토해야_하는_원서를_가져온다() {
+        // given
+        List<Form> formList = List.of(
+                FormFixture.createForm(FormType.REGULAR),
+                FormFixture.createForm(FormType.REGULAR),
+                FormFixture.createForm(FormType.REGULAR)
+        );
+        given(formRepository.findByStatus(FormStatus.SUBMITTED)).willReturn(formList);
+
+        // when
+        List<FormResponse> formResponseList = querySubmittedFormUseCase.execute();
+
+        // then
+        verify(formRepository, times(1)).findByStatus(FormStatus.SUBMITTED);
+        assertEquals(formResponseList.size(), formList.size());
+        assertEquals(formResponseList.get(0).getId(), formList.get(0).getId());
+        assertEquals(formResponseList.get(1).getId(), formList.get(1).getId());
+        assertEquals(formResponseList.get(2).getId(), formList.get(2).getId());
+    }
+
+    @Test
+    void 검토해야_하는_원서가_없으면_빈_리스트를_반환한다() {
+        // given
+        given(formRepository.findByStatus(FormStatus.SUBMITTED)).willReturn(List.of());
+
+        // when
+        List<FormResponse> formResponseList = querySubmittedFormUseCase.execute();
+
+        // then
+        verify(formRepository, times(1)).findByStatus(FormStatus.SUBMITTED);
+        assertEquals(formResponseList.size(), 0);
+    }
+
+}

--- a/src/test/java/com/bamdoliro/maru/application/form/RejectFormUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/RejectFormUseCaseTest.java
@@ -1,0 +1,54 @@
+package com.bamdoliro.maru.application.form;
+
+import com.bamdoliro.maru.domain.form.domain.Form;
+import com.bamdoliro.maru.domain.form.domain.type.FormStatus;
+import com.bamdoliro.maru.domain.form.domain.type.FormType;
+import com.bamdoliro.maru.domain.form.exception.FormNotFoundException;
+import com.bamdoliro.maru.domain.form.service.FormFacade;
+import com.bamdoliro.maru.shared.fixture.FormFixture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class RejectFormUseCaseTest {
+
+    @InjectMocks
+    private RejectFormUseCase rejectFormUseCase;
+
+    @Mock
+    private FormFacade formFacade;
+
+    @Test
+    void 원서를_반려한다() {
+        // given
+        Form form = FormFixture.createForm(FormType.REGULAR);
+        given(formFacade.getForm(form.getId())).willReturn(form);
+
+        // when
+        rejectFormUseCase.execute(form.getId());
+
+        // then
+        verify(formFacade).getForm(form.getId());
+        assertEquals(form.getStatus(), FormStatus.REJECTED);
+    }
+
+    @Test
+    void 원서를_반려할_때_원서가_없으면_에러가_발생한다() {
+        // given
+        Form form = FormFixture.createForm(FormType.REGULAR);
+        willThrow(new FormNotFoundException()).given(formFacade).getForm(form.getId());
+
+        // when and then
+        assertThrows(FormNotFoundException.class, () -> rejectFormUseCase.execute(form.getId()));
+        assertEquals(form.getStatus(), FormStatus.SUBMITTED);
+    }
+}

--- a/src/test/java/com/bamdoliro/maru/domain/form/service/FormFacadeTest.java
+++ b/src/test/java/com/bamdoliro/maru/domain/form/service/FormFacadeTest.java
@@ -3,11 +3,8 @@ package com.bamdoliro.maru.domain.form.service;
 import com.bamdoliro.maru.domain.form.domain.Form;
 import com.bamdoliro.maru.domain.form.domain.type.FormType;
 import com.bamdoliro.maru.domain.form.exception.FormNotFoundException;
-import com.bamdoliro.maru.domain.user.domain.User;
-import com.bamdoliro.maru.domain.user.exception.UserNotFoundException;
 import com.bamdoliro.maru.infrastructure.persistence.form.FormRepository;
 import com.bamdoliro.maru.shared.fixture.FormFixture;
-import com.bamdoliro.maru.shared.fixture.UserFixture;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -16,9 +13,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/com/bamdoliro/maru/domain/form/service/FormFacadeTest.java
+++ b/src/test/java/com/bamdoliro/maru/domain/form/service/FormFacadeTest.java
@@ -1,0 +1,54 @@
+package com.bamdoliro.maru.domain.form.service;
+
+import com.bamdoliro.maru.domain.form.domain.Form;
+import com.bamdoliro.maru.domain.form.domain.type.FormType;
+import com.bamdoliro.maru.domain.form.exception.FormNotFoundException;
+import com.bamdoliro.maru.domain.user.domain.User;
+import com.bamdoliro.maru.domain.user.exception.UserNotFoundException;
+import com.bamdoliro.maru.infrastructure.persistence.form.FormRepository;
+import com.bamdoliro.maru.shared.fixture.FormFixture;
+import com.bamdoliro.maru.shared.fixture.UserFixture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class FormFacadeTest {
+
+    @InjectMocks
+    private FormFacade formFacade;
+
+    @Mock
+    private FormRepository formRepository;
+
+    @Test
+    void 원서를_가져온다() {
+        // given
+        Form form = FormFixture.createForm(FormType.REGULAR);
+        given(formRepository.findById(form.getId())).willReturn(Optional.of(form));
+
+        // when
+        Form foundForm = formFacade.getForm(form.getId());
+
+        // then
+        assertEquals(form.getId(), foundForm.getId());
+    }
+
+    @Test
+    void 존재하지_않는_원서일_때_에러가_발생한다() {
+        // given
+        given(formRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // when and then
+        assertThrows(FormNotFoundException.class, () -> formFacade.getForm(415L));
+    }
+}

--- a/src/test/java/com/bamdoliro/maru/presentation/form/FormControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/presentation/form/FormControllerTest.java
@@ -2,6 +2,7 @@ package com.bamdoliro.maru.presentation.form;
 
 import com.bamdoliro.maru.domain.form.domain.type.FormType;
 import com.bamdoliro.maru.domain.form.exception.FormAlreadySubmittedException;
+import com.bamdoliro.maru.domain.form.exception.FormNotFoundException;
 import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.presentation.form.dto.request.ApplicantRequest;
 import com.bamdoliro.maru.presentation.form.dto.request.FormRequest;
@@ -21,21 +22,26 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class FormControllerTest extends RestDocsTestSupport {
 
     @Test
     void 원서를_접수한다() throws Exception {
-        User user = UserFixture.createUser();
         FormRequest request = FormFixture.createFormRequest(FormType.REGULAR);
         willDoNothing().given(submitFormUseCase).execute(request);
+
+        User user = UserFixture.createUser();
         given(jwtProperties.getPrefix()).willReturn("Bearer");
         given(tokenService.getEmail(anyString())).willReturn(user.getEmail());
         given(authDetailsService.loadUserByUsername(user.getEmail())).willReturn(new AuthDetails(user));
@@ -181,9 +187,10 @@ class FormControllerTest extends RestDocsTestSupport {
 
     @Test
     void 중졸_껌정고시_합격자가_원서를_접수한다() throws Exception {
-        User user = UserFixture.createUser();
         FormRequest request = FormFixture.createQualificationExaminationFormRequest(FormType.MEISTER_TALENT);
         willDoNothing().given(submitFormUseCase).execute(request);
+
+        User user = UserFixture.createUser();
         given(jwtProperties.getPrefix()).willReturn("Bearer");
         given(tokenService.getEmail(anyString())).willReturn(user.getEmail());
         given(authDetailsService.loadUserByUsername(user.getEmail())).willReturn(new AuthDetails(user));
@@ -202,12 +209,13 @@ class FormControllerTest extends RestDocsTestSupport {
 
     @Test
     void 원서를_접수할_때_이미_접수한_원서가_있으면_에러가_발생한다() throws Exception {
-        User user = UserFixture.createUser();
         FormRequest request = FormFixture.createFormRequest(FormType.REGULAR);
+        doThrow(new FormAlreadySubmittedException()).when(submitFormUseCase).execute(any(FormRequest.class));
+
+        User user = UserFixture.createUser();
         given(jwtProperties.getPrefix()).willReturn("Bearer");
         given(tokenService.getEmail(anyString())).willReturn(user.getEmail());
         given(authDetailsService.loadUserByUsername(user.getEmail())).willReturn(new AuthDetails(user));
-        doThrow(new FormAlreadySubmittedException()).when(submitFormUseCase).execute(any(FormRequest.class));
 
         mockMvc.perform(post("/form")
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
@@ -223,8 +231,9 @@ class FormControllerTest extends RestDocsTestSupport {
 
     @Test
     void 원서를_접수할_때_잘못된_형식의_요청을_보내면_에러가_발생한다() throws Exception {
-        User user = UserFixture.createUser();
         FormRequest request = new FormRequest();
+
+        User user = UserFixture.createUser();
         given(jwtProperties.getPrefix()).willReturn("Bearer");
         given(tokenService.getEmail(anyString())).willReturn(user.getEmail());
         given(authDetailsService.loadUserByUsername(user.getEmail())).willReturn(new AuthDetails(user));
@@ -241,5 +250,111 @@ class FormControllerTest extends RestDocsTestSupport {
                 .andDo(restDocs.document());
 
         verify(submitFormUseCase, never()).execute(any(FormRequest.class));
+    }
+
+    @Test
+    void 원서를_승인한다() throws Exception {
+        Long formId = 1L;
+        willDoNothing().given(approveFormUseCase).execute(formId);
+
+        User user = UserFixture.createAdminUser();
+        given(jwtProperties.getPrefix()).willReturn("Bearer");
+        given(tokenService.getEmail(anyString())).willReturn(user.getEmail());
+        given(authDetailsService.loadUserByUsername(user.getEmail())).willReturn(new AuthDetails(user));
+
+        mockMvc.perform(patch("/form/{form-id}/approve", formId)
+                        .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
+                        .accept(MediaType.APPLICATION_JSON)
+                )
+
+                .andExpect(status().isNoContent())
+
+                .andDo(restDocs.document(
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION)
+                                        .description("Bearer token")
+                        ),
+                        pathParameters(
+                                parameterWithName("form-id")
+                                        .description("승인할 원서의 id")
+                        )
+                ));
+
+        verify(approveFormUseCase, times(1)).execute(formId);
+    }
+
+    @Test
+    void 원서를_승인할_때_원서가_없으면_에러가_발생한다() throws Exception {
+        Long formId = 1L;
+        doThrow(new FormNotFoundException()).when(approveFormUseCase).execute(formId);
+
+        User user = UserFixture.createAdminUser();
+        given(jwtProperties.getPrefix()).willReturn("Bearer");
+        given(tokenService.getEmail(anyString())).willReturn(user.getEmail());
+        given(authDetailsService.loadUserByUsername(user.getEmail())).willReturn(new AuthDetails(user));
+
+        mockMvc.perform(patch("/form/{form-id}/approve", formId)
+                        .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
+                        .accept(MediaType.APPLICATION_JSON)
+                )
+
+                .andExpect(status().isNotFound())
+
+                .andDo(restDocs.document());
+
+        verify(approveFormUseCase, times(1)).execute(formId);
+    }
+
+    @Test
+    void 원서를_반려한다() throws Exception {
+        Long formId = 1L;
+        willDoNothing().given(rejectFormUseCase).execute(formId);
+
+        User user = UserFixture.createAdminUser();
+        given(jwtProperties.getPrefix()).willReturn("Bearer");
+        given(tokenService.getEmail(anyString())).willReturn(user.getEmail());
+        given(authDetailsService.loadUserByUsername(user.getEmail())).willReturn(new AuthDetails(user));
+
+        mockMvc.perform(patch("/form/{form-id}/reject", formId)
+                        .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
+                        .accept(MediaType.APPLICATION_JSON)
+                )
+
+                .andExpect(status().isNoContent())
+
+                .andDo(restDocs.document(
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION)
+                                        .description("Bearer token")
+                        ),
+                        pathParameters(
+                                parameterWithName("form-id")
+                                        .description("반려할 원서의 id")
+                        )
+                ));
+
+        verify(rejectFormUseCase, times(1)).execute(formId);
+    }
+
+    @Test
+    void 원서를_반려할_때_원서가_없으면_에러가_발생한다() throws Exception {
+        Long formId = 1L;
+        doThrow(new FormNotFoundException()).when(rejectFormUseCase).execute(formId);
+
+        User user = UserFixture.createAdminUser();
+        given(jwtProperties.getPrefix()).willReturn("Bearer");
+        given(tokenService.getEmail(anyString())).willReturn(user.getEmail());
+        given(authDetailsService.loadUserByUsername(user.getEmail())).willReturn(new AuthDetails(user));
+
+        mockMvc.perform(patch("/form/{form-id}/reject", formId)
+                        .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
+                        .accept(MediaType.APPLICATION_JSON)
+                )
+
+                .andExpect(status().isNotFound())
+
+                .andDo(restDocs.document());
+
+        verify(rejectFormUseCase, times(1)).execute(formId);
     }
 }

--- a/src/test/java/com/bamdoliro/maru/presentation/school/SchoolControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/presentation/school/SchoolControllerTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
+import java.util.List;
+
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
@@ -67,7 +69,7 @@ class SchoolControllerTest extends RestDocsTestSupport {
     @Test
     void 학교를_검색할_때_결과가_없다면_빈_리스트를_반환한다() throws Exception {
         User user = UserFixture.createUser();
-        given(searchSchoolUseCase.execute(anyString())).willReturn(SchoolFixture.createEmptySchoolListResponse());
+        given(searchSchoolUseCase.execute(anyString())).willReturn(List.of());
         given(jwtProperties.getPrefix()).willReturn("Bearer");
         given(tokenService.getEmail(anyString())).willReturn(user.getEmail());
         given(authDetailsService.loadUserByUsername(user.getEmail())).willReturn(new AuthDetails(user));

--- a/src/test/java/com/bamdoliro/maru/shared/fixture/FormFixture.java
+++ b/src/test/java/com/bamdoliro/maru/shared/fixture/FormFixture.java
@@ -3,6 +3,7 @@ package com.bamdoliro.maru.shared.fixture;
 import com.bamdoliro.maru.domain.form.domain.Form;
 import com.bamdoliro.maru.domain.form.domain.type.AchievementLevel;
 import com.bamdoliro.maru.domain.form.domain.type.Certificate;
+import com.bamdoliro.maru.domain.form.domain.type.FormStatus;
 import com.bamdoliro.maru.domain.form.domain.type.FormType;
 import com.bamdoliro.maru.domain.form.domain.type.Gender;
 import com.bamdoliro.maru.domain.form.domain.type.GraduationType;
@@ -25,6 +26,7 @@ import com.bamdoliro.maru.presentation.form.dto.request.FormRequest;
 import com.bamdoliro.maru.presentation.form.dto.request.GradeRequest;
 import com.bamdoliro.maru.presentation.form.dto.request.ParentRequest;
 import com.bamdoliro.maru.presentation.form.dto.request.SubjectRequest;
+import com.bamdoliro.maru.presentation.form.dto.response.FormResponse;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -249,6 +251,14 @@ public class FormFixture {
                         "공부열심히할게용"
                 ),
                 type
+        );
+    }
+
+    public static FormResponse createFormResponse(FormStatus status) {
+        return new FormResponse(
+                1L,
+                "김밤돌",
+                status
         );
     }
 }

--- a/src/test/java/com/bamdoliro/maru/shared/fixture/SchoolFixture.java
+++ b/src/test/java/com/bamdoliro/maru/shared/fixture/SchoolFixture.java
@@ -26,8 +26,4 @@ public class SchoolFixture {
                 new SchoolResponse("또다른비전중학교", "경기도", "7631003")
         );
     }
-
-    public static List<SchoolResponse> createEmptySchoolListResponse() {
-        return List.of();
-    }
 }

--- a/src/test/java/com/bamdoliro/maru/shared/fixture/UserFixture.java
+++ b/src/test/java/com/bamdoliro/maru/shared/fixture/UserFixture.java
@@ -2,11 +2,16 @@ package com.bamdoliro.maru.shared.fixture;
 
 import com.bamdoliro.maru.domain.user.domain.EmailVerification;
 import com.bamdoliro.maru.domain.user.domain.User;
+import com.bamdoliro.maru.domain.user.domain.type.Authority;
 
 public class UserFixture {
 
     public static User createUser() {
-        return new User("maru@bamdoliro.com", "비밀번호");
+        return new User("maru@bamdoliro.com", "비밀번호", Authority.ROLE_USER);
+    }
+
+    public static User createAdminUser() {
+        return new User("maru@bamdoliro.com", "비밀번호", Authority.ROLE_ADMIN);
     }
 
     public static EmailVerification createVerification() {

--- a/src/test/java/com/bamdoliro/maru/shared/util/ControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/shared/util/ControllerTest.java
@@ -3,6 +3,7 @@ package com.bamdoliro.maru.shared.util;
 import com.bamdoliro.maru.application.auth.LogInUseCase;
 import com.bamdoliro.maru.application.auth.RefreshTokenUseCase;
 import com.bamdoliro.maru.application.form.ApproveFormUseCase;
+import com.bamdoliro.maru.application.form.QuerySubmittedFormUseCase;
 import com.bamdoliro.maru.application.form.RejectFormUseCase;
 import com.bamdoliro.maru.application.form.SubmitFormUseCase;
 import com.bamdoliro.maru.application.school.SearchSchoolUseCase;
@@ -69,6 +70,9 @@ public abstract class ControllerTest {
 
     @MockBean
     protected RejectFormUseCase rejectFormUseCase;
+
+    @MockBean
+    protected QuerySubmittedFormUseCase querySubmittedFormUseCase;
 
 
     @MockBean

--- a/src/test/java/com/bamdoliro/maru/shared/util/ControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/shared/util/ControllerTest.java
@@ -2,6 +2,8 @@ package com.bamdoliro.maru.shared.util;
 
 import com.bamdoliro.maru.application.auth.LogInUseCase;
 import com.bamdoliro.maru.application.auth.RefreshTokenUseCase;
+import com.bamdoliro.maru.application.form.ApproveFormUseCase;
+import com.bamdoliro.maru.application.form.RejectFormUseCase;
 import com.bamdoliro.maru.application.form.SubmitFormUseCase;
 import com.bamdoliro.maru.application.school.SearchSchoolUseCase;
 import com.bamdoliro.maru.application.user.SendEmailVerificationUseCase;
@@ -61,6 +63,12 @@ public abstract class ControllerTest {
 
     @MockBean
     protected SubmitFormUseCase submitFormUseCase;
+
+    @MockBean
+    protected ApproveFormUseCase approveFormUseCase;
+
+    @MockBean
+    protected RejectFormUseCase rejectFormUseCase;
 
 
     @MockBean


### PR DESCRIPTION
## 🎫 관련 이슈

close #16

<br>

## 📄 개요
> 원서를 검토할 수 있는 기능을 만들었습니다.

<br>

## 🔨 작업 내용
- 원서 수락 / 거부 API
- 원서 쿼리 API


<br>

## 🏁 확인 사항

- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [ ] 코드 컨벤션을 준수했나요?

<br>

## 🙋🏻 덧붙일 말
문서 불러오기는 선생님이 만들지 않아도 된다고 하셔서 안 만들었습니당