### PR TITLE
[버그] 증명사진 업로드 중 원서를 찾을 수 없음

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+generated/
 HELP.md
 .gradle
 build/

--- a/src/main/java/com/bamdoliro/maru/application/form/UploadFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/UploadFormUseCase.java
@@ -1,7 +1,5 @@
 package com.bamdoliro.maru.application.form;
 
-import com.bamdoliro.maru.domain.form.domain.Form;
-import com.bamdoliro.maru.domain.form.service.FormFacade;
 import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.infrastructure.s3.UploadFileService;
 import com.bamdoliro.maru.infrastructure.s3.constants.FolderConstant;
@@ -13,21 +11,16 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.UUID;
-
 import static com.bamdoliro.maru.shared.constants.FileConstants.MB;
 
 @RequiredArgsConstructor
 @UseCase
 public class UploadFormUseCase {
 
-    private final FormFacade formFacade;
     private final UploadFileService uploadFileService;
 
     public UploadResponse execute(User user, MultipartFile formFile) {
-        UUID uuid = formFacade.getFormUuid(user);
-
-        return uploadFileService.execute(formFile, FolderConstant.FORM, uuid.toString(), file -> {
+        return uploadFileService.execute(formFile, FolderConstant.FORM, user.getUuid().toString(), file -> {
             if (file.getContentType() != null && !file.getContentType().equals(MediaType.APPLICATION_PDF_VALUE)) {
                 throw new MediaTypeMismatchException();
             }

--- a/src/main/java/com/bamdoliro/maru/application/form/UploadIdentificationPictureUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/UploadIdentificationPictureUseCase.java
@@ -1,6 +1,5 @@
 package com.bamdoliro.maru.application.form;
 
-import com.bamdoliro.maru.domain.form.service.FormFacade;
 import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.infrastructure.s3.UploadFileService;
 import com.bamdoliro.maru.infrastructure.s3.constants.FolderConstant;
@@ -17,7 +16,6 @@ import org.springframework.web.multipart.MultipartFile;
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
-import java.util.UUID;
 
 import static com.bamdoliro.maru.shared.constants.FileConstants.MB;
 
@@ -25,13 +23,10 @@ import static com.bamdoliro.maru.shared.constants.FileConstants.MB;
 @UseCase
 public class UploadIdentificationPictureUseCase {
 
-    private final FormFacade formFacade;
     private final UploadFileService uploadFileService;
 
     public UploadResponse execute(User user, MultipartFile image) {
-        UUID uuid = formFacade.getFormUuid(user);
-
-        return uploadFileService.execute(image, FolderConstant.IDENTIFICATION_PICTURE, uuid.toString(), file -> {
+        return uploadFileService.execute(image, FolderConstant.IDENTIFICATION_PICTURE, user.getUuid().toString(), file -> {
             if (file.getContentType() != null && !(
                     file.getContentType().equals(MediaType.IMAGE_JPEG_VALUE) ||
                             file.getContentType().equals(MediaType.IMAGE_PNG_VALUE)

--- a/src/main/java/com/bamdoliro/maru/domain/form/domain/Form.java
+++ b/src/main/java/com/bamdoliro/maru/domain/form/domain/Form.java
@@ -43,8 +43,6 @@ public class Form extends BaseTimeEntity {
     @Column(nullable = true, unique = true)
     private Long examinationNumber;
 
-    private UUID uuid;
-
     @Embedded
     private Applicant applicant;
 
@@ -87,7 +85,6 @@ public class Form extends BaseTimeEntity {
         this.document = document;
         this.type = type;
         this.user = user;
-        this.uuid = UUID.randomUUID();
         this.status = FormStatus.DRAFT;
     }
 

--- a/src/main/java/com/bamdoliro/maru/domain/form/service/FormFacade.java
+++ b/src/main/java/com/bamdoliro/maru/domain/form/service/FormFacade.java
@@ -24,9 +24,4 @@ public class FormFacade {
         return formRepository.findByUser(user)
                 .orElseThrow(FormNotFoundException::new);
     }
-
-    public UUID getFormUuid(User user) {
-        return formRepository.findFormUuidByUser(user)
-                .orElseThrow(FormNotFoundException::new);
-    }
 }

--- a/src/main/java/com/bamdoliro/maru/domain/user/domain/User.java
+++ b/src/main/java/com/bamdoliro/maru/domain/user/domain/User.java
@@ -18,6 +18,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.UUID;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "tbl_user")
@@ -28,6 +30,9 @@ public class User extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
     private Long id;
+
+    @Column(unique = true, nullable = false)
+    private UUID uuid;
 
     @Column(unique = true, nullable = false, length = 100)
     private String email;
@@ -41,6 +46,7 @@ public class User extends BaseTimeEntity {
 
     @Builder
     public User(String email, String password, Authority authority) {
+        this.uuid = UUID.randomUUID();
         this.email = email;
         this.password = new Password(PasswordUtil.encode(password));
         this.authority = authority;

--- a/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepository.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepository.java
@@ -1,15 +1,12 @@
 package com.bamdoliro.maru.infrastructure.persistence.form;
 
 import com.bamdoliro.maru.domain.form.domain.Form;
-import com.bamdoliro.maru.domain.form.domain.type.FormStatus;
 import com.bamdoliro.maru.domain.user.domain.User;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 public interface FormRepository extends CrudRepository<Form, Long>, FormRepositoryCustom {
 
@@ -22,9 +19,4 @@ public interface FormRepository extends CrudRepository<Form, Long>, FormReposito
             "WHERE f.examinationNumber BETWEEN :minValue AND :maxValue")
     Optional<Long> findMaxExaminationNumber(
             @Param("minValue") Long minValue, @Param("maxValue") Long maxValue);
-
-    @Query("SELECT f.uuid " +
-            "FROM Form f " +
-            "WHERE f.user = :user")
-    Optional<UUID> findFormUuidByUser(@Param("user") User user);
 }

--- a/src/test/java/com/bamdoliro/maru/application/form/UploadFormUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/UploadFormUseCaseTest.java
@@ -2,7 +2,6 @@ package com.bamdoliro.maru.application.form;
 
 import com.bamdoliro.maru.domain.form.domain.Form;
 import com.bamdoliro.maru.domain.form.domain.type.FormType;
-import com.bamdoliro.maru.domain.form.service.FormFacade;
 import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.infrastructure.s3.UploadFileService;
 import com.bamdoliro.maru.infrastructure.s3.dto.response.UploadResponse;
@@ -20,7 +19,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.nio.charset.StandardCharsets;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
@@ -31,9 +29,6 @@ class UploadFormUseCaseTest {
 
     @InjectMocks
     private UploadFormUseCase uploadFormUseCase;
-
-    @Mock
-    private FormFacade formFacade;
 
     @Mock
     private UploadFileService uploadFileService;
@@ -49,14 +44,12 @@ class UploadFormUseCaseTest {
                 MediaType.APPLICATION_PDF_VALUE,
                 "<<file>>".getBytes(StandardCharsets.UTF_8)
         );
-        given(formFacade.getFormUuid(user)).willReturn(form.getUuid());
         given(uploadFileService.execute(any(MultipartFile.class), any(String.class), any(String.class), any(FileValidator.class))).willReturn(new UploadResponse("https://host.com/image.pdf"));
 
         // when
         uploadFormUseCase.execute(user, image);
 
         // then
-        verify(formFacade, times(1)).getFormUuid(user);
         verify(uploadFileService, times(1)).execute(any(MultipartFile.class), any(String.class), any(String.class), any(FileValidator.class));
     }
 }

--- a/src/test/java/com/bamdoliro/maru/application/form/UploadIdentificationPictureUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/UploadIdentificationPictureUseCaseTest.java
@@ -2,7 +2,6 @@ package com.bamdoliro.maru.application.form;
 
 import com.bamdoliro.maru.domain.form.domain.Form;
 import com.bamdoliro.maru.domain.form.domain.type.FormType;
-import com.bamdoliro.maru.domain.form.service.FormFacade;
 import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.infrastructure.s3.UploadFileService;
 import com.bamdoliro.maru.infrastructure.s3.dto.response.UploadResponse;
@@ -23,7 +22,6 @@ import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.times;
@@ -34,9 +32,6 @@ class UploadIdentificationPictureUseCaseTest {
 
     @InjectMocks
     private UploadIdentificationPictureUseCase uploadIdentificationPictureUseCase;
-
-    @Mock
-    private FormFacade formFacade;
 
     @Mock
     private UploadFileService uploadFileService;
@@ -53,14 +48,12 @@ class UploadIdentificationPictureUseCaseTest {
                 MediaType.IMAGE_PNG_VALUE,
                 "<<image>>".getBytes(StandardCharsets.UTF_8)
         );
-        given(formFacade.getFormUuid(user)).willReturn(form.getUuid());
         given(uploadFileService.execute(any(MultipartFile.class), any(String.class), any(String.class), any(FileValidator.class))).willReturn(new UploadResponse("https://host.com/image.png"));
 
         // when
         uploadIdentificationPictureUseCase.execute(user, image);
 
         // then
-        verify(formFacade, times(1)).getFormUuid(user);
         verify(uploadFileService, times(1)).execute(any(MultipartFile.class), any(String.class), any(String.class), any(FileValidator.class));
     }
 
@@ -76,14 +69,12 @@ class UploadIdentificationPictureUseCaseTest {
                 MediaType.IMAGE_PNG_VALUE,
                 "<<image>>".getBytes(StandardCharsets.UTF_8)
         );
-        given(formFacade.getFormUuid(user)).willReturn(form.getUuid());
         willThrow(ImageSizeMismatchException.class).given(uploadFileService).execute(any(MultipartFile.class), any(String.class), any(String.class), any(FileValidator.class));
 
         // when and then
         assertThrows(ImageSizeMismatchException.class,
                 () -> uploadIdentificationPictureUseCase.execute(user, image));
 
-        verify(formFacade, times(1)).getFormUuid(user);
         verify(uploadFileService, times(1)).execute(any(MultipartFile.class), any(String.class), any(String.class), any(FileValidator.class));
     }
 }


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #46

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 원서가 없으면 증명사진 업로드 불가능

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- 원서, 증명사진 url을 form이 아니라 user UUID로 하는 것으로 변경

<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [x] 테스트를 완료했나요?
- [ ] API 문서를 작성했나요?
- [ ] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

