### PR TITLE
[개선] Reject 및 Approve 디비에 저장 및 반려된 지원자는 다시 원서를 제출 할 수 있어야함

### DIFF
--- a/src/main/java/com/bamdoliro/maru/application/form/ApproveFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/ApproveFormUseCase.java
@@ -4,6 +4,7 @@ import com.bamdoliro.maru.domain.form.domain.Form;
 import com.bamdoliro.maru.domain.form.service.FormFacade;
 import com.bamdoliro.maru.shared.annotation.UseCase;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @UseCase
@@ -11,6 +12,7 @@ public class ApproveFormUseCase {
 
     private final FormFacade formFacade;
 
+    @Transactional
     public void execute(Long id) {
         Form form = formFacade.getForm(id);
         form.approve();

--- a/src/main/java/com/bamdoliro/maru/application/form/RejectFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/RejectFormUseCase.java
@@ -4,6 +4,7 @@ import com.bamdoliro.maru.domain.form.domain.Form;
 import com.bamdoliro.maru.domain.form.service.FormFacade;
 import com.bamdoliro.maru.shared.annotation.UseCase;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @UseCase
@@ -11,6 +12,7 @@ public class RejectFormUseCase {
 
     private final FormFacade formFacade;
 
+    @Transactional
     public void execute(Long id) {
         Form form = formFacade.getForm(id);
         form.reject();


### PR DESCRIPTION
- 반려된 원서를 재제출 할 수 있게 하기 위해서 Reject를 디비에 저장할 수 있게 트랜잭션을 달았어요

## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #88

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

>  Reject와 Approve도 디비에 저장되도록 변경했습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- Reject와 Approve에 트랜잭션 어노테이션을 달아서 디비에 반영되게 했습니다.


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [ ] 테스트를 완료했나요?
- [ ] API 문서를 작성했나요?
- [ x 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

