### PR TITLE
[버그] 입학설명회 조회 버그 수정

### DIFF
--- a/src/main/java/com/bamdoliro/maru/presentation/fair/dto/response/FairDetailResponse.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/fair/dto/response/FairDetailResponse.java
@@ -17,6 +17,7 @@ public class FairDetailResponse {
 
     private LocalDateTime start;
     private String place;
+    private String applicationUrl;
     private LocalDate applicationStartDate;
     private LocalDate applicationEndDate;
     private FairStatus status;
@@ -25,6 +26,7 @@ public class FairDetailResponse {
     public FairDetailResponse(Fair fair, AttendeeRepository attendeeRepository) {
         this.start = fair.getStart();
         this.place = fair.getPlace();
+        this.applicationUrl = fair.getApplicationUrl();
         this.applicationStartDate = fair.getApplicationStartDate();
         this.applicationEndDate = fair.getApplicationEndDate();
         this.status = fair.getStatus(attendeeRepository);

--- a/src/main/java/com/bamdoliro/maru/presentation/fair/dto/response/FairResponse.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/fair/dto/response/FairResponse.java
@@ -15,6 +15,7 @@ public class FairResponse {
 
     private LocalDateTime start;
     private String place;
+    private String applicationUrl;
     private LocalDate applicationStartDate;
     private LocalDate applicationEndDate;
     private FairStatus status;
@@ -22,6 +23,7 @@ public class FairResponse {
     public FairResponse(Fair fair, AttendeeRepository attendeeRepository) {
         this.start = fair.getStart();
         this.place = fair.getPlace();
+        this.applicationUrl = fair.getApplicationUrl();
         this.applicationStartDate = fair.getApplicationStartDate();
         this.applicationEndDate = fair.getApplicationEndDate();
         this.status = fair.getStatus(attendeeRepository);


### PR DESCRIPTION
- 원서 조회시 applicationUrl이 보이지 않는 오류를 수정했어요.

## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #86

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 입학설명회 조회시 applicationUrl이 보이지 않는 문제를 해결했습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- FairResponse에 applicationUrl을 추가했습니다.
- FairDetialResponse에 applicationUrl을 추가했습니다.


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

