### PR TITLE
[새기능] 최종 합격 자동화 및 점수 순 정렬

### DIFF
--- a/src/docs/asciidoc/form.adoc
+++ b/src/docs/asciidoc/form.adoc
@@ -586,3 +586,23 @@ include::{snippets}/form-controller-test/선택한_원서의_원서url을_조회
 
 ===== 정상 응답
 include::{snippets}/form-controller-test/선택한_원서의_원서url을_조회한다/http-response.adoc[]
+
+
+
+=== 2차 합격 자동 처리
+
+==== 요청 형식
+
+===== Request Header
+include::{snippets}/form-controller-test/자동으로_2차_합격_여부를_결정한다/request-headers.adoc[]
+
+==== 요청
+include::{snippets}/form-controller-test/자동으로_2차_합격_여부를_결정한다/http-request.adoc[]
+
+==== 응답
+
+===== 정상 응답
+include::{snippets}/form-controller-test/자동으로_2차_합격_여부를_결정한다/http-response.adoc[]
+
+===== 최종 점수가 없는 원서가 있을 경우
+include::{snippets}/form-controller-test/자동으로_2차_합격_여부를_결정할_때_최종_점수가_없는_원서가_존재하면_에러가_발생한다/http-response.adoc[]

--- a/src/main/java/com/bamdoliro/maru/application/form/GenerateAdmissionTicketUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/GenerateAdmissionTicketUseCase.java
@@ -1,7 +1,7 @@
 package com.bamdoliro.maru.application.form;
 
 import com.bamdoliro.maru.domain.form.domain.Form;
-import com.bamdoliro.maru.domain.form.exception.InvalidFromStatusException;
+import com.bamdoliro.maru.domain.form.exception.InvalidFormStatusException;
 import com.bamdoliro.maru.domain.form.service.FormFacade;
 import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.infrastructure.pdf.GeneratePdfService;
@@ -48,7 +48,7 @@ public class GenerateAdmissionTicketUseCase {
 
     private void validateFormStatus(Form form) {
         if (!form.isFirstPassedNow()) {
-            throw new InvalidFromStatusException();
+            throw new InvalidFormStatusException();
         }
     }
 }

--- a/src/main/java/com/bamdoliro/maru/application/form/QueryAllFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/QueryAllFormUseCase.java
@@ -3,6 +3,7 @@ package com.bamdoliro.maru.application.form;
 import com.bamdoliro.maru.domain.form.domain.Form;
 import com.bamdoliro.maru.domain.form.domain.type.FormStatus;
 import com.bamdoliro.maru.domain.form.domain.type.FormType;
+import com.bamdoliro.maru.domain.form.exception.MissingTotalScoreException;
 import com.bamdoliro.maru.infrastructure.persistence.form.FormRepository;
 import com.bamdoliro.maru.presentation.form.dto.response.FormSimpleResponse;
 import com.bamdoliro.maru.shared.annotation.UseCase;
@@ -24,6 +25,9 @@ public class QueryAllFormUseCase {
                 .filter(form -> Objects.isNull(category) || form.getType().categoryEquals(category))
                 .toList());
 
+        if (sort != null && formList.stream().anyMatch(form -> form.getScore().getTotalScore() == null)) {
+            throw new MissingTotalScoreException();
+        }
         if ("total-score-asc".equals(sort)) {
             formList.sort(Comparator.comparing(form -> form.getScore().getTotalScore(), Comparator.naturalOrder()));
         } else if ("total-score-desc".equals(sort)) {

--- a/src/main/java/com/bamdoliro/maru/application/form/QueryAllFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/QueryAllFormUseCase.java
@@ -1,5 +1,6 @@
 package com.bamdoliro.maru.application.form;
 
+import com.bamdoliro.maru.domain.form.domain.Form;
 import com.bamdoliro.maru.domain.form.domain.type.FormStatus;
 import com.bamdoliro.maru.domain.form.domain.type.FormType;
 import com.bamdoliro.maru.infrastructure.persistence.form.FormRepository;
@@ -7,6 +8,7 @@ import com.bamdoliro.maru.presentation.form.dto.response.FormSimpleResponse;
 import com.bamdoliro.maru.shared.annotation.UseCase;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -17,9 +19,20 @@ public class QueryAllFormUseCase {
 
     private final FormRepository formRepository;
 
-    public List<FormSimpleResponse> execute(FormStatus status, FormType.Category category) {
-        return formRepository.findByStatus(status).stream()
+    public List<FormSimpleResponse> execute(FormStatus status, FormType.Category category, String orderBy, String order) {
+        List<Form> forms = new java.util.ArrayList<>(formRepository.findByStatus(status).stream()
                 .filter(form -> Objects.isNull(category) || form.getType().categoryEquals(category))
+                .toList());
+
+        if (orderBy.equals("totalScore")) {
+            if (order.equals("asc")) {
+                forms.sort(Comparator.comparing(form -> form.getScore().getTotalScore(), Comparator.naturalOrder()));
+            } else if (order.equals("desc")) {
+                forms.sort(Comparator.comparing(form -> form.getScore().getTotalScore()));
+            }
+        }
+
+        return forms.stream()
                 .map(FormSimpleResponse::new)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/bamdoliro/maru/application/form/QueryAllFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/QueryAllFormUseCase.java
@@ -19,17 +19,15 @@ public class QueryAllFormUseCase {
 
     private final FormRepository formRepository;
 
-    public List<FormSimpleResponse> execute(FormStatus status, FormType.Category category, String orderBy, String order) {
+    public List<FormSimpleResponse> execute(FormStatus status, FormType.Category category, String sort) {
         List<Form> forms = new java.util.ArrayList<>(formRepository.findByStatus(status).stream()
                 .filter(form -> Objects.isNull(category) || form.getType().categoryEquals(category))
                 .toList());
 
-        if (orderBy.equals("totalScore")) {
-            if (order.equals("asc")) {
-                forms.sort(Comparator.comparing(form -> form.getScore().getTotalScore(), Comparator.naturalOrder()));
-            } else if (order.equals("desc")) {
-                forms.sort(Comparator.comparing(form -> form.getScore().getTotalScore()));
-            }
+        if (sort.equals("total-score-asc")) {
+            forms.sort(Comparator.comparing(form -> form.getScore().getTotalScore(), Comparator.naturalOrder()));
+        } else if (sort.equals("total-score-desc")) {
+            forms.sort(Comparator.comparing(form -> form.getScore().getTotalScore(), Comparator.reverseOrder()));
         }
 
         return forms.stream()

--- a/src/main/java/com/bamdoliro/maru/application/form/QueryAllFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/QueryAllFormUseCase.java
@@ -20,17 +20,17 @@ public class QueryAllFormUseCase {
     private final FormRepository formRepository;
 
     public List<FormSimpleResponse> execute(FormStatus status, FormType.Category category, String sort) {
-        List<Form> forms = new java.util.ArrayList<>(formRepository.findByStatus(status).stream()
+        List<Form> formList = new java.util.ArrayList<>(formRepository.findByStatus(status).stream()
                 .filter(form -> Objects.isNull(category) || form.getType().categoryEquals(category))
                 .toList());
 
-        if (sort.equals("total-score-asc")) {
-            forms.sort(Comparator.comparing(form -> form.getScore().getTotalScore(), Comparator.naturalOrder()));
-        } else if (sort.equals("total-score-desc")) {
-            forms.sort(Comparator.comparing(form -> form.getScore().getTotalScore(), Comparator.reverseOrder()));
+        if ("total-score-asc".equals(sort)) {
+            formList.sort(Comparator.comparing(form -> form.getScore().getTotalScore(), Comparator.naturalOrder()));
+        } else if ("total-score-desc".equals(sort)) {
+            formList.sort(Comparator.comparing(form -> form.getScore().getTotalScore(), Comparator.reverseOrder()));
         }
 
-        return forms.stream()
+        return formList.stream()
                 .map(FormSimpleResponse::new)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/bamdoliro/maru/application/form/SelectFirstPassUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/SelectFirstPassUseCase.java
@@ -6,6 +6,7 @@ import com.bamdoliro.maru.domain.form.service.CalculateFormScoreService;
 import com.bamdoliro.maru.infrastructure.persistence.form.FormRepository;
 import com.bamdoliro.maru.shared.annotation.UseCase;
 import com.bamdoliro.maru.shared.constants.FixedNumber;
+import com.bamdoliro.maru.shared.variable.AdmissionCapacity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,12 +35,16 @@ public class SelectFirstPassUseCase {
             int gap = FixedNumber.MEISTER_TALENT - meisterTalentFormList.size();
             regularCount += gap;
             meisterTalentCount -= gap;
+            AdmissionCapacity.regular += gap;
+            AdmissionCapacity.meisterTalent -= gap;
         }
 
         if (socialIntegrationFormList.size() < FixedNumber.SOCIAL_INTEGRATION) {
             int gap = FixedNumber.SOCIAL_INTEGRATION - socialIntegrationFormList.size();
             regularCount += gap;
             socialIntegrationCount -= gap;
+            AdmissionCapacity.regular += gap;
+            AdmissionCapacity.socialIntegration -= gap;
         }
 
         regularCount = calculateMultiple(regularCount);

--- a/src/main/java/com/bamdoliro/maru/application/form/SelectFirstPassUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/SelectFirstPassUseCase.java
@@ -78,22 +78,29 @@ public class SelectFirstPassUseCase {
         }
 
         formRepository.flush();
-        List<Form> regularOrSupernumeraryFormList = formRepository.findReceivedRegularOrSupernumeraryForm();
+        List<Form> regularOrSupernumeraryFormList = formRepository.findReceivedRegularForm();
 
         for (Form form : regularOrSupernumeraryFormList) {
-            if (form.getType().isRegular() && regularCount > 0) {
+            if (regularCount > 0) {
                 form.firstPass();
                 regularCount--;
-            } else if (
+            } else {
+                form.firstFail();
+            }
+        }
+
+        formRepository.flush();
+        List<Form> supernumeraryFormList = formRepository.findReceivedSupernumeraryForm();
+
+        for (Form form : supernumeraryFormList) {
+            if (
                     form.getType().isNationalVeteransEducation() &&
-                            regularCount > 0 &&
                             nationalVeteransEducationCount > 0
             ) {
                 form.firstPass();
                 nationalVeteransEducationCount--;
             } else if (
                     form.getType().isSpecialAdmission() &&
-                            regularCount > 0 &&
                             specialAdmissionCount > 0
             ) {
                 form.firstPass();

--- a/src/main/java/com/bamdoliro/maru/application/form/SelectSecondPassUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/SelectSecondPassUseCase.java
@@ -1,0 +1,101 @@
+package com.bamdoliro.maru.application.form;
+
+import com.bamdoliro.maru.domain.form.domain.Form;
+import com.bamdoliro.maru.domain.form.domain.type.FormStatus;
+import com.bamdoliro.maru.domain.form.domain.type.FormType;
+import com.bamdoliro.maru.domain.form.exception.TotalScoreMissingException;
+import com.bamdoliro.maru.infrastructure.persistence.form.FormRepository;
+import com.bamdoliro.maru.shared.annotation.UseCase;
+import com.bamdoliro.maru.shared.constants.FixedNumber;
+import com.bamdoliro.maru.shared.variable.AdmissionCapacity;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@UseCase
+public class SelectSecondPassUseCase {
+
+    private final FormRepository formRepository;
+
+    @Transactional
+    public void execute() {
+        validate();
+
+        int regularCount = AdmissionCapacity.regular;
+        int meisterTalentCount = AdmissionCapacity.meisterTalent;
+        int socialIntegrationCount = AdmissionCapacity.socialIntegration;
+        int nationalVeteransEducationCount = FixedNumber.NATIONAL_VETERANS_EDUCATION;
+        int specialAdmissionCount = FixedNumber.SPECIAL_ADMISSION;
+        int equalOpportunityCount = (int) Math.round(socialIntegrationCount * 0.5);
+        int societyDiversityCount = equalOpportunityCount;
+
+        List<Form> specialFormList = formRepository.findFirstPassedSpecialForm();
+        List<Form> meisterTalentFormList = classifyFormsByType(specialFormList, FormType::isMeister);
+        List<Form> socialIntegrationFormList = classifyFormsByType(specialFormList, FormType::isSocial);
+
+        for (Form form : socialIntegrationFormList) {
+            if (form.getType().isEqualOpportunity() && equalOpportunityCount > 0) {
+                form.pass();
+                equalOpportunityCount--;
+            } else if (form.getType().isSocietyDiversity() && societyDiversityCount > 0) {
+                form.pass();
+                societyDiversityCount--;
+            } else {
+                form.fail();
+            }
+        }
+
+        for (Form form : meisterTalentFormList) {
+            if (meisterTalentCount > 0) {
+                form.pass();
+                meisterTalentCount--;
+            } else {
+                form.fail();
+            }
+        }
+
+        formRepository.flush();
+        List<Form> regularOrSupernumeraryFormList = formRepository.findFirstPassedRegularOrSupernumeraryForm();
+        System.out.println(regularOrSupernumeraryFormList.size());
+
+        for (Form form : regularOrSupernumeraryFormList) {
+            if (form.getType().isRegular() && regularCount > 0) {
+                form.pass();
+                regularCount--;
+            } else if (
+                    form.getType().isNationalVeteransEducation() &&
+                            regularCount > 0 &&
+                            nationalVeteransEducationCount > 0
+            ) {
+                form.pass();
+                nationalVeteransEducationCount--;
+            } else if (
+                    form.getType().isSpecialAdmission() &&
+                            regularCount > 0 &&
+                            specialAdmissionCount > 0
+            ) {
+                form.pass();
+                specialAdmissionCount--;
+            } else {
+                form.fail();
+            }
+        }
+    }
+
+    private void validate() {
+        List<Form> firstPassedFormList = formRepository.findByStatus(FormStatus.FIRST_PASSED);
+        for (Form form : firstPassedFormList) {
+            if (form.getScore().getTotalScore() == null) {
+                throw new TotalScoreMissingException();
+            }
+        }
+    }
+
+    private List<Form> classifyFormsByType(List<Form> formList, FormTypeFilter filter) {
+        return formList.stream()
+                .filter(form -> filter.execute(form.getType()))
+                .toList();
+    }
+}

--- a/src/main/java/com/bamdoliro/maru/domain/form/domain/type/FormType.java
+++ b/src/main/java/com/bamdoliro/maru/domain/form/domain/type/FormType.java
@@ -19,7 +19,7 @@ public enum FormType implements EnumProperty {
     NATIONAL_VETERANS("국가보훈자녀", Category.SPECIAL, Category.SOCIAL_INTEGRATION, Category.EQUAL_OPPORTUNITY),
     ONE_PARENT("한부모가정", Category.SPECIAL, Category.SOCIAL_INTEGRATION, Category.EQUAL_OPPORTUNITY),
 
-    FROM_NORTH_KOREA("북한이탈주민", Category.SPECIAL, Category.SOCIAL_INTEGRATION, Category.SOCIETY_DIVERSITY),
+    FROM_NORTH_KOREA("북한이탈청소년", Category.SPECIAL, Category.SOCIAL_INTEGRATION, Category.SOCIETY_DIVERSITY),
     MULTICULTURAL("다문화가정", Category.SPECIAL, Category.SOCIAL_INTEGRATION, Category.SOCIETY_DIVERSITY),
     TEEN_HOUSEHOLDER("소년소녀가장", Category.SPECIAL, Category.SOCIAL_INTEGRATION, Category.SOCIETY_DIVERSITY),
     MULTI_CHILDREN("다자녀가정자녀", Category.SPECIAL, Category.SOCIAL_INTEGRATION, Category.SOCIETY_DIVERSITY),

--- a/src/main/java/com/bamdoliro/maru/domain/form/exception/InvalidFormStatusException.java
+++ b/src/main/java/com/bamdoliro/maru/domain/form/exception/InvalidFormStatusException.java
@@ -3,9 +3,9 @@ package com.bamdoliro.maru.domain.form.exception;
 import com.bamdoliro.maru.domain.form.exception.error.FormErrorProperty;
 import com.bamdoliro.maru.shared.error.MaruException;
 
-public class InvalidFromStatusException extends MaruException {
+public class InvalidFormStatusException extends MaruException {
 
-    public InvalidFromStatusException() {
+    public InvalidFormStatusException() {
         super(FormErrorProperty.INVALID_FORM_STATUS);
     }
 }

--- a/src/main/java/com/bamdoliro/maru/domain/form/exception/MissingTotalScoreException.java
+++ b/src/main/java/com/bamdoliro/maru/domain/form/exception/MissingTotalScoreException.java
@@ -3,8 +3,8 @@ package com.bamdoliro.maru.domain.form.exception;
 import com.bamdoliro.maru.domain.form.exception.error.FormErrorProperty;
 import com.bamdoliro.maru.shared.error.MaruException;
 
-public class TotalScoreMissingException extends MaruException {
-    public TotalScoreMissingException() {
+public class MissingTotalScoreException extends MaruException {
+    public MissingTotalScoreException() {
         super(FormErrorProperty.TOTAL_SCORE_MISSING);
     }
 }

--- a/src/main/java/com/bamdoliro/maru/domain/form/exception/MissingTotalScoreException.java
+++ b/src/main/java/com/bamdoliro/maru/domain/form/exception/MissingTotalScoreException.java
@@ -5,6 +5,6 @@ import com.bamdoliro.maru.shared.error.MaruException;
 
 public class MissingTotalScoreException extends MaruException {
     public MissingTotalScoreException() {
-        super(FormErrorProperty.TOTAL_SCORE_MISSING);
+        super(FormErrorProperty.MISSING_TOTAL_SCORE);
     }
 }

--- a/src/main/java/com/bamdoliro/maru/domain/form/exception/TotalScoreMissingException.java
+++ b/src/main/java/com/bamdoliro/maru/domain/form/exception/TotalScoreMissingException.java
@@ -1,0 +1,11 @@
+package com.bamdoliro.maru.domain.form.exception;
+
+import com.bamdoliro.maru.domain.form.exception.error.FormErrorProperty;
+import com.bamdoliro.maru.shared.error.ErrorProperty;
+import com.bamdoliro.maru.shared.error.MaruException;
+
+public class TotalScoreMissingException extends MaruException {
+    public TotalScoreMissingException() {
+        super(FormErrorProperty.TOTAL_SCORE_MISSING);
+    }
+}

--- a/src/main/java/com/bamdoliro/maru/domain/form/exception/TotalScoreMissingException.java
+++ b/src/main/java/com/bamdoliro/maru/domain/form/exception/TotalScoreMissingException.java
@@ -1,7 +1,6 @@
 package com.bamdoliro.maru.domain.form.exception;
 
 import com.bamdoliro.maru.domain.form.exception.error.FormErrorProperty;
-import com.bamdoliro.maru.shared.error.ErrorProperty;
 import com.bamdoliro.maru.shared.error.MaruException;
 
 public class TotalScoreMissingException extends MaruException {

--- a/src/main/java/com/bamdoliro/maru/domain/form/exception/TotalScoreMissingException.java
+++ b/src/main/java/com/bamdoliro/maru/domain/form/exception/TotalScoreMissingException.java
@@ -5,6 +5,6 @@ import com.bamdoliro.maru.shared.error.MaruException;
 
 public class TotalScoreMissingException extends MaruException {
     public TotalScoreMissingException() {
-        super(FormErrorProperty.TOTAL_SCORE_MISSING);
+        super(FormErrorProperty.MISSING_TOTAL_SCORE);
     }
 }

--- a/src/main/java/com/bamdoliro/maru/domain/form/exception/error/FormErrorProperty.java
+++ b/src/main/java/com/bamdoliro/maru/domain/form/exception/error/FormErrorProperty.java
@@ -15,6 +15,7 @@ public enum FormErrorProperty implements ErrorProperty {
     CANNOT_UPDATE_NOT_REJECTED_FORM(HttpStatus.CONFLICT, "반려된 원서만 수정할 수 있습니다."),
     INVALID_FORM_STATUS(HttpStatus.CONFLICT, "원서 상태가 유효하지 않습니다."),
     INVALID_FILE(HttpStatus.BAD_REQUEST, "잘못된 파일입니다."),
+    TOTAL_SCORE_MISSING(HttpStatus.PRECONDITION_FAILED, "최종 점수가 입력되지 않은 원서가 존재합니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/bamdoliro/maru/domain/form/exception/error/FormErrorProperty.java
+++ b/src/main/java/com/bamdoliro/maru/domain/form/exception/error/FormErrorProperty.java
@@ -15,7 +15,7 @@ public enum FormErrorProperty implements ErrorProperty {
     CANNOT_UPDATE_NOT_REJECTED_FORM(HttpStatus.CONFLICT, "반려된 원서만 수정할 수 있습니다."),
     INVALID_FORM_STATUS(HttpStatus.CONFLICT, "원서 상태가 유효하지 않습니다."),
     INVALID_FILE(HttpStatus.BAD_REQUEST, "잘못된 파일입니다."),
-    MISSING_TOTAL_SCORE(HttpStatus.PRECONDITION_FAILED, "최종 점수가 입력되지 않은 원서가 존재합니다.")
+    MISSING_TOTAL_SCORE(HttpStatus.PRECONDITION_FAILED, "최종 점수가 입력되지 않은 원서가 존재합니다."),
     WRONG_SCORE(HttpStatus.BAD_REQUEST, "점수 범위를 초과했습니다."),
     ;
 

--- a/src/main/java/com/bamdoliro/maru/domain/form/exception/error/FormErrorProperty.java
+++ b/src/main/java/com/bamdoliro/maru/domain/form/exception/error/FormErrorProperty.java
@@ -15,7 +15,7 @@ public enum FormErrorProperty implements ErrorProperty {
     CANNOT_UPDATE_NOT_REJECTED_FORM(HttpStatus.CONFLICT, "반려된 원서만 수정할 수 있습니다."),
     INVALID_FORM_STATUS(HttpStatus.CONFLICT, "원서 상태가 유효하지 않습니다."),
     INVALID_FILE(HttpStatus.BAD_REQUEST, "잘못된 파일입니다."),
-    TOTAL_SCORE_MISSING(HttpStatus.PRECONDITION_FAILED, "최종 점수가 입력되지 않은 원서가 존재합니다.")
+    MISSING_TOTAL_SCORE(HttpStatus.PRECONDITION_FAILED, "최종 점수가 입력되지 않은 원서가 존재합니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepositoryCustom.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepositoryCustom.java
@@ -11,6 +11,8 @@ public interface FormRepositoryCustom {
     List<Form> findByStatus(FormStatus status);
     List<Form> findReceivedSpecialForm();
     List<Form> findReceivedRegularOrSupernumeraryForm();
+    List<Form> findFirstPassedSpecialForm();
+    List<Form> findFirstPassedRegularOrSupernumeraryForm();
     List<Form> findFirstRoundForm();
     List<Form> findMeisterTalentFirstRoundForm();
     List<Form> findNotExistsMeisterTalentAndChangedToRegularFirstRoundForm();

--- a/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepositoryCustom.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepositoryCustom.java
@@ -17,6 +17,8 @@ public interface FormRepositoryCustom {
     List<Form> findByCategory(FormType.Category category);
     List<Form> findReceivedSpecialForm();
     List<Form> findReceivedRegularOrSupernumeraryForm();
+    List<Form> findFirstPassedSpecialForm();
+    List<Form> findFirstPassedRegularOrSupernumeraryForm();
     List<Form> findFirstRoundForm();
     List<Form> findMeisterTalentFirstRoundForm();
     List<Form> findNotExistsMeisterTalentAndChangedToRegularFirstRoundForm();

--- a/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepositoryCustom.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepositoryCustom.java
@@ -16,9 +16,11 @@ public interface FormRepositoryCustom {
     List<Form> findByType(FormType type);
     List<Form> findByCategory(FormType.Category category);
     List<Form> findReceivedSpecialForm();
-    List<Form> findReceivedRegularOrSupernumeraryForm();
+    List<Form> findReceivedRegularForm();
+    List<Form> findReceivedSupernumeraryForm();
     List<Form> findFirstPassedSpecialForm();
-    List<Form> findFirstPassedRegularOrSupernumeraryForm();
+    List<Form> findFirstPassedRegularForm();
+    List<Form> findFirstPassedSupernumeraryForm();
     List<Form> findFirstRoundForm();
     List<Form> findMeisterTalentFirstRoundForm();
     List<Form> findNotExistsMeisterTalentAndChangedToRegularFirstRoundForm();

--- a/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepositoryImpl.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepositoryImpl.java
@@ -161,13 +161,18 @@ public class FormRepositoryImpl implements FormRepositoryCustom {
 
     @Override
     public List<Form> findFirstPassedSupernumeraryForm() {
-        return List.of();
+        return queryFactory
+                .selectFrom(form)
+                .where(
+                        form.status.eq(FormStatus.FIRST_PASSED)
+                                .and(
+                                        form.type.eq(FormType.SPECIAL_ADMISSION)
+                                                .or(form.type.eq(FormType.NATIONAL_VETERANS_EDUCATION))
+                                )
+                )
+                .orderBy(form.score.totalScore.desc())
+                .fetch();
     }
-
-//    @Override
-//    public List<Form> findFirstPassedRegularOrSupernumeraryForm() {
-//
-//    }
 
     @Override
     public List<Form> findFirstRoundForm() {

--- a/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepositoryImpl.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepositoryImpl.java
@@ -110,6 +110,43 @@ public class FormRepositoryImpl implements FormRepositoryCustom {
     }
 
     @Override
+    public List<Form> findFirstPassedSpecialForm() {
+        return queryFactory
+                .selectFrom(form)
+                .where(
+                        form.status.eq(FormStatus.FIRST_PASSED)
+                                .and(
+                                        form.type.eq(FormType.REGULAR).not()
+                                                .and(form.type.eq(FormType.NATIONAL_VETERANS_EDUCATION).not())
+                                                .and(form.type.eq(FormType.SPECIAL_ADMISSION).not())
+                                )
+                )
+                .orderBy(
+                        form.score.totalScore.desc()
+                )
+                .fetch();
+    }
+
+    @Override
+    public List<Form> findFirstPassedRegularOrSupernumeraryForm() {
+        return queryFactory
+                .selectFrom(form)
+                .where(
+                        form.status.eq(FormStatus.FIRST_PASSED)
+                                .and(
+                                        form.type.eq(FormType.REGULAR)
+                                                .or(form.type.eq(FormType.NATIONAL_VETERANS_EDUCATION))
+                                                .or(form.type.eq(FormType.SPECIAL_ADMISSION))
+                                                .or(form.changedToRegular.isTrue())
+                                )
+                )
+                .orderBy(
+                        form.score.totalScore.desc()
+                )
+                .fetch();
+    }
+
+    @Override
     public List<Form> findFirstRoundForm() {
         return queryFactory
                 .selectFrom(form)

--- a/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepositoryImpl.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepositoryImpl.java
@@ -84,9 +84,7 @@ public class FormRepositoryImpl implements FormRepositoryCustom {
                                                 .and(form.type.eq(FormType.SPECIAL_ADMISSION).not())
                                 )
                 )
-                .orderBy(
-                        form.score.firstRoundScore.desc()
-                )
+                .orderBy(form.score.firstRoundScore.desc())
                 .fetch();
     }
 
@@ -101,9 +99,7 @@ public class FormRepositoryImpl implements FormRepositoryCustom {
                                                 .or(form.changedToRegular.isTrue())
                                 )
                 )
-                .orderBy(
-                        form.score.firstRoundScore.desc()
-                )
+                .orderBy(form.score.firstRoundScore.desc())
                 .fetch();
     }
 
@@ -118,9 +114,7 @@ public class FormRepositoryImpl implements FormRepositoryCustom {
                                                 .or(form.type.eq(FormType.NATIONAL_VETERANS_EDUCATION))
                                 )
                 )
-                .orderBy(
-                        form.score.firstRoundScore.desc()
-                )
+                .orderBy(form.score.firstRoundScore.desc())
                 .fetch();
     }
 
@@ -136,9 +130,7 @@ public class FormRepositoryImpl implements FormRepositoryCustom {
                                                 .and(form.type.eq(FormType.SPECIAL_ADMISSION).not())
                                 )
                 )
-                .orderBy(
-                        form.score.totalScore.desc()
-                )
+                .orderBy(form.score.totalScore.desc())
                 .fetch();
     }
 
@@ -153,9 +145,7 @@ public class FormRepositoryImpl implements FormRepositoryCustom {
                                                 .or(form.changedToRegular.isTrue())
                                 )
                 )
-                .orderBy(
-                        form.score.totalScore.desc()
-                )
+                .orderBy(form.score.totalScore.desc())
                 .fetch();
     }
 

--- a/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepositoryImpl.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepositoryImpl.java
@@ -76,6 +76,43 @@ public class FormRepositoryImpl implements FormRepositoryCustom {
     }
 
     @Override
+    public List<Form> findFirstPassedSpecialForm() {
+        return queryFactory
+                .selectFrom(form)
+                .where(
+                        form.status.eq(FormStatus.FIRST_PASSED)
+                                .and(
+                                        form.type.eq(FormType.REGULAR).not()
+                                                .and(form.type.eq(FormType.NATIONAL_VETERANS_EDUCATION).not())
+                                                .and(form.type.eq(FormType.SPECIAL_ADMISSION).not())
+                                )
+                )
+                .orderBy(
+                        form.score.totalScore.desc()
+                )
+                .fetch();
+    }
+
+    @Override
+    public List<Form> findFirstPassedRegularOrSupernumeraryForm() {
+        return queryFactory
+                .selectFrom(form)
+                .where(
+                        form.status.eq(FormStatus.FIRST_PASSED)
+                                .and(
+                                        form.type.eq(FormType.REGULAR)
+                                                .or(form.type.eq(FormType.NATIONAL_VETERANS_EDUCATION))
+                                                .or(form.type.eq(FormType.SPECIAL_ADMISSION))
+                                                .or(form.changedToRegular.isTrue())
+                                )
+                )
+                .orderBy(
+                        form.score.totalScore.desc()
+                )
+                .fetch();
+    }
+
+    @Override
     public List<Form> findFirstRoundForm() {
         return queryFactory
                 .selectFrom(form)

--- a/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepositoryImpl.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepositoryImpl.java
@@ -91,16 +91,31 @@ public class FormRepositoryImpl implements FormRepositoryCustom {
     }
 
     @Override
-    public List<Form> findReceivedRegularOrSupernumeraryForm() {
+    public List<Form> findReceivedRegularForm() {
         return queryFactory
                 .selectFrom(form)
                 .where(
                         form.status.eq(FormStatus.RECEIVED)
                                 .and(
                                         form.type.eq(FormType.REGULAR)
-                                                .or(form.type.eq(FormType.NATIONAL_VETERANS_EDUCATION))
-                                                .or(form.type.eq(FormType.SPECIAL_ADMISSION))
                                                 .or(form.changedToRegular.isTrue())
+                                )
+                )
+                .orderBy(
+                        form.score.firstRoundScore.desc()
+                )
+                .fetch();
+    }
+
+    @Override
+    public List<Form> findReceivedSupernumeraryForm() {
+        return queryFactory
+                .selectFrom(form)
+                .where(
+                        form.status.eq(FormStatus.RECEIVED)
+                                .and(
+                                        form.type.eq(FormType.SPECIAL_ADMISSION)
+                                                .or(form.type.eq(FormType.NATIONAL_VETERANS_EDUCATION))
                                 )
                 )
                 .orderBy(
@@ -128,15 +143,13 @@ public class FormRepositoryImpl implements FormRepositoryCustom {
     }
 
     @Override
-    public List<Form> findFirstPassedRegularOrSupernumeraryForm() {
+    public List<Form> findFirstPassedRegularForm() {
         return queryFactory
                 .selectFrom(form)
                 .where(
                         form.status.eq(FormStatus.FIRST_PASSED)
                                 .and(
                                         form.type.eq(FormType.REGULAR)
-                                                .or(form.type.eq(FormType.NATIONAL_VETERANS_EDUCATION))
-                                                .or(form.type.eq(FormType.SPECIAL_ADMISSION))
                                                 .or(form.changedToRegular.isTrue())
                                 )
                 )
@@ -145,6 +158,16 @@ public class FormRepositoryImpl implements FormRepositoryCustom {
                 )
                 .fetch();
     }
+
+    @Override
+    public List<Form> findFirstPassedSupernumeraryForm() {
+        return List.of();
+    }
+
+//    @Override
+//    public List<Form> findFirstPassedRegularOrSupernumeraryForm() {
+//
+//    }
 
     @Override
     public List<Form> findFirstRoundForm() {

--- a/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
@@ -69,6 +69,7 @@ public class FormController {
     private final ExportResultUseCase exportResultUseCase;
     private final PassOrFailFormUseCase passOrFailFormUseCase;
     private final QueryFormUrlUseCase queryFormUrlUseCase;
+    private final SelectFirstPassUseCase selectFirstPassUseCase;
     private final SelectSecondPassUseCase selectSecondPassUseCase;
 
     @ResponseStatus(HttpStatus.CREATED)
@@ -192,10 +193,12 @@ public class FormController {
     public ListCommonResponse<FormSimpleResponse> getFormList(
             @AuthenticationPrincipal(authority = Authority.ADMIN) User user,
             @RequestParam(name = "status", required = false) FormStatus status,
-            @RequestParam(name = "type", required = false) FormType.Category type
+            @RequestParam(name = "type", required = false) FormType.Category type,
+            @RequestParam(name = "order-by", required = false) String orderBy,
+            @RequestParam(name = "order", required = false) String order
     ) {
         return ListCommonResponse.ok(
-                queryAllFormUseCase.execute(status, type)
+                queryAllFormUseCase.execute(status, type, orderBy, order)
         );
     }
 
@@ -297,6 +300,18 @@ public class FormController {
         return CommonResponse.ok(
                 queryFormUrlUseCase.execute(formIdList)
         );
+    }
+
+    /**
+     * 테스트용 메서드. 커밋 전에 삭제해야함.
+     * @param user
+     */
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PatchMapping("/first-round/select")
+    public void selectFirstPass(
+            @AuthenticationPrincipal(authority = Authority.ADMIN) User user
+    ) {
+        selectFirstPassUseCase.execute();
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
@@ -1,29 +1,6 @@
 package com.bamdoliro.maru.presentation.form;
 
-import com.bamdoliro.maru.application.form.ApproveFormUseCase;
-import com.bamdoliro.maru.application.form.DownloadSecondRoundScoreFormatUseCase;
-import com.bamdoliro.maru.application.form.ExportFinalPassedFormUseCase;
-import com.bamdoliro.maru.application.form.ExportFirstRoundResultUseCase;
-import com.bamdoliro.maru.application.form.ExportFormUseCase;
-import com.bamdoliro.maru.application.form.ExportResultUseCase;
-import com.bamdoliro.maru.application.form.ExportSecondRoundResultUseCase;
-import com.bamdoliro.maru.application.form.GenerateAdmissionTicketUseCase;
-import com.bamdoliro.maru.application.form.PassOrFailFormUseCase;
-import com.bamdoliro.maru.application.form.QueryAllFormUseCase;
-import com.bamdoliro.maru.application.form.QueryFinalFormResultUseCase;
-import com.bamdoliro.maru.application.form.QueryFirstFormResultUseCase;
-import com.bamdoliro.maru.application.form.QueryFormStatusUseCase;
-import com.bamdoliro.maru.application.form.QueryFormUrlUseCase;
-import com.bamdoliro.maru.application.form.QueryFormUseCase;
-import com.bamdoliro.maru.application.form.QuerySubmittedFormUseCase;
-import com.bamdoliro.maru.application.form.ReceiveFormUseCase;
-import com.bamdoliro.maru.application.form.RejectFormUseCase;
-import com.bamdoliro.maru.application.form.SubmitFinalFormUseCase;
-import com.bamdoliro.maru.application.form.SubmitFormUseCase;
-import com.bamdoliro.maru.application.form.UpdateFormUseCase;
-import com.bamdoliro.maru.application.form.UpdateSecondRoundScoreUseCase;
-import com.bamdoliro.maru.application.form.UploadFormUseCase;
-import com.bamdoliro.maru.application.form.UploadIdentificationPictureUseCase;
+import com.bamdoliro.maru.application.form.*;
 import com.bamdoliro.maru.domain.form.domain.type.FormStatus;
 import com.bamdoliro.maru.domain.form.domain.type.FormType;
 import com.bamdoliro.maru.domain.user.domain.User;
@@ -92,6 +69,7 @@ public class FormController {
     private final ExportResultUseCase exportResultUseCase;
     private final PassOrFailFormUseCase passOrFailFormUseCase;
     private final QueryFormUrlUseCase queryFormUrlUseCase;
+    private final SelectSecondPassUseCase selectSecondPassUseCase;
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
@@ -319,5 +297,12 @@ public class FormController {
         return CommonResponse.ok(
                 queryFormUrlUseCase.execute(formIdList)
         );
+    }
+
+    @PatchMapping("/second-pass")
+    public void selectSecondPass(
+            @AuthenticationPrincipal(authority = Authority.ADMIN) User user
+    ) {
+        selectSecondPassUseCase.execute();
     }
 }

--- a/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
@@ -69,7 +69,6 @@ public class FormController {
     private final ExportResultUseCase exportResultUseCase;
     private final PassOrFailFormUseCase passOrFailFormUseCase;
     private final QueryFormUrlUseCase queryFormUrlUseCase;
-    private final SelectFirstPassUseCase selectFirstPassUseCase;
     private final SelectSecondPassUseCase selectSecondPassUseCase;
 
     @ResponseStatus(HttpStatus.CREATED)
@@ -299,18 +298,6 @@ public class FormController {
         return CommonResponse.ok(
                 queryFormUrlUseCase.execute(formIdList)
         );
-    }
-
-    /**
-     * 테스트용 메서드. 커밋 전에 삭제해야함.
-     * @param user
-     */
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    @PatchMapping("/first-round/select")
-    public void selectFirstPass(
-            @AuthenticationPrincipal(authority = Authority.ADMIN) User user
-    ) {
-        selectFirstPassUseCase.execute();
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
@@ -299,7 +299,8 @@ public class FormController {
         );
     }
 
-    @PatchMapping("/second-pass")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PatchMapping("/second-round/select")
     public void selectSecondPass(
             @AuthenticationPrincipal(authority = Authority.ADMIN) User user
     ) {

--- a/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
@@ -194,11 +194,10 @@ public class FormController {
             @AuthenticationPrincipal(authority = Authority.ADMIN) User user,
             @RequestParam(name = "status", required = false) FormStatus status,
             @RequestParam(name = "type", required = false) FormType.Category type,
-            @RequestParam(name = "order-by", required = false) String orderBy,
-            @RequestParam(name = "order", required = false) String order
+            @RequestParam(name = "sort", required = false) String sort
     ) {
         return ListCommonResponse.ok(
-                queryAllFormUseCase.execute(status, type, orderBy, order)
+                queryAllFormUseCase.execute(status, type, sort)
         );
     }
 

--- a/src/main/java/com/bamdoliro/maru/shared/variable/AdmissionCapacity.java
+++ b/src/main/java/com/bamdoliro/maru/shared/variable/AdmissionCapacity.java
@@ -1,11 +1,12 @@
 package com.bamdoliro.maru.shared.variable;
 
+import com.bamdoliro.maru.shared.constants.FixedNumber;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class AdmissionCapacity {
 
-    public static int regular = 36;
-    public static int meisterTalent = 25;
-    public static int socialIntegration = 3;
+    public static int regular = FixedNumber.REGULAR;
+    public static int meisterTalent = FixedNumber.MEISTER_TALENT;
+    public static int socialIntegration = FixedNumber.SOCIAL_INTEGRATION;
 }

--- a/src/main/java/com/bamdoliro/maru/shared/variable/AdmissionCapacity.java
+++ b/src/main/java/com/bamdoliro/maru/shared/variable/AdmissionCapacity.java
@@ -1,0 +1,11 @@
+package com.bamdoliro.maru.shared.variable;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class AdmissionCapacity {
+
+    public static int regular = 36;
+    public static int meisterTalent = 25;
+    public static int socialIntegration = 3;
+}

--- a/src/test/java/com/bamdoliro/maru/application/form/GenerateAdmissionTicketUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/GenerateAdmissionTicketUseCaseTest.java
@@ -3,12 +3,11 @@ package com.bamdoliro.maru.application.form;
 import com.bamdoliro.maru.domain.form.domain.Form;
 import com.bamdoliro.maru.domain.form.domain.type.FormType;
 import com.bamdoliro.maru.domain.form.exception.FormNotFoundException;
-import com.bamdoliro.maru.domain.form.exception.InvalidFromStatusException;
+import com.bamdoliro.maru.domain.form.exception.InvalidFormStatusException;
 import com.bamdoliro.maru.domain.form.service.FormFacade;
 import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.infrastructure.pdf.GeneratePdfService;
 import com.bamdoliro.maru.infrastructure.thymeleaf.ProcessTemplateService;
-import com.bamdoliro.maru.infrastructure.thymeleaf.Templates;
 import com.bamdoliro.maru.shared.fixture.FormFixture;
 import com.bamdoliro.maru.shared.fixture.UserFixture;
 import org.junit.jupiter.api.Test;
@@ -22,7 +21,6 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
@@ -71,7 +69,7 @@ class GenerateAdmissionTicketUseCaseTest {
         given(formFacade.getForm(user)).willReturn(form);
 
         // when and then
-        assertThrows(InvalidFromStatusException.class, () -> generateAdmissionTicketUseCase.execute(user));
+        assertThrows(InvalidFormStatusException.class, () -> generateAdmissionTicketUseCase.execute(user));
 
         verify(formFacade, times(1)).getForm(user);
         verify(processTemplateService, never()).execute(any(String.class), any(Map.class));

--- a/src/test/java/com/bamdoliro/maru/application/form/QueryAllFormUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/QueryAllFormUseCaseTest.java
@@ -5,12 +5,15 @@ import com.bamdoliro.maru.domain.form.domain.type.FormType;
 import com.bamdoliro.maru.infrastructure.persistence.form.FormRepository;
 import com.bamdoliro.maru.presentation.form.dto.response.FormSimpleResponse;
 import com.bamdoliro.maru.shared.fixture.FormFixture;
+import com.bamdoliro.maru.shared.util.RandomUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -40,7 +43,7 @@ class QueryAllFormUseCaseTest {
         given(formRepository.findByStatus(null)).willReturn(formList);
 
         // when
-        List<FormSimpleResponse> returnedFormList = queryAllFormUseCase.execute(null, null);
+        List<FormSimpleResponse> returnedFormList = queryAllFormUseCase.execute(null, null, null);
 
         // then
         assertEquals(formList.size(), returnedFormList.size());
@@ -61,7 +64,7 @@ class QueryAllFormUseCaseTest {
         given(formRepository.findByStatus(null)).willReturn(formList);
 
         // when
-        List<FormSimpleResponse> returnedFormList = queryAllFormUseCase.execute(null, FormType.Category.SPECIAL);
+        List<FormSimpleResponse> returnedFormList = queryAllFormUseCase.execute(null, FormType.Category.SPECIAL, null);
 
         // then
         assertEquals(2, returnedFormList.size());
@@ -82,10 +85,88 @@ class QueryAllFormUseCaseTest {
         given(formRepository.findByStatus(null)).willReturn(formList);
 
         // when
-        List<FormSimpleResponse> returnedFormList = queryAllFormUseCase.execute(null, FormType.Category.SOCIAL_INTEGRATION);
+        List<FormSimpleResponse> returnedFormList = queryAllFormUseCase.execute(null, FormType.Category.SOCIAL_INTEGRATION, null);
 
         // then
         assertEquals(1, returnedFormList.size());
+
+        verify(formRepository, times(1)).findByStatus(null);
+    }
+
+    @Test
+    void 최종_점수가_높은_순으로_조회한다() {
+        // given
+        List<Form> formList = List.of(
+                FormFixture.createForm(FormType.REGULAR),
+                FormFixture.createForm(FormType.SPECIAL_ADMISSION),
+                FormFixture.createForm(FormType.MEISTER_TALENT),
+                FormFixture.createForm(FormType.MULTI_CHILDREN)
+        );
+
+        formList.stream()
+                .filter(form -> form.getType() == FormType.MEISTER_TALENT)
+                .forEach(form -> form.getScore().updateSecondRoundMeisterScore(
+                        RandomUtil.randomDouble(10, 50),
+                        RandomUtil.randomDouble(10, 50),
+                        RandomUtil.randomDouble(10, 50)
+                ));
+        formList.stream()
+                .filter(form -> form.getType() != FormType.MEISTER_TALENT)
+                .forEach(form -> form.getScore().updateSecondRoundScore(
+                        RandomUtil.randomDouble(10, 50),
+                        RandomUtil.randomDouble(10, 50)
+                ));
+        given(formRepository.findByStatus(null)).willReturn(formList);
+
+        // when
+        List<FormSimpleResponse> returnedFormList = queryAllFormUseCase.execute(null, null, "total-score-desc");
+
+        // then
+        assertEquals(
+                Collections.max(formList, Comparator.comparingDouble(form -> form.getScore().getTotalScore()))
+                        .getScore()
+                        .getTotalScore(),
+                returnedFormList.get(0).getTotalScore()
+        );
+
+        verify(formRepository, times(1)).findByStatus(null);
+    }
+
+    @Test
+    void 최종_점수가_낮은_순으로_조회한다() {
+        // given
+        List<Form> formList = List.of(
+                FormFixture.createForm(FormType.REGULAR),
+                FormFixture.createForm(FormType.SPECIAL_ADMISSION),
+                FormFixture.createForm(FormType.MEISTER_TALENT),
+                FormFixture.createForm(FormType.MULTI_CHILDREN)
+        );
+
+        formList.stream()
+                .filter(form -> form.getType() == FormType.MEISTER_TALENT)
+                .forEach(form -> form.getScore().updateSecondRoundMeisterScore(
+                        RandomUtil.randomDouble(10, 50),
+                        RandomUtil.randomDouble(10, 50),
+                        RandomUtil.randomDouble(10, 50)
+                ));
+        formList.stream()
+                .filter(form -> form.getType() != FormType.MEISTER_TALENT)
+                .forEach(form -> form.getScore().updateSecondRoundScore(
+                        RandomUtil.randomDouble(10, 50),
+                        RandomUtil.randomDouble(10, 50)
+                ));
+        given(formRepository.findByStatus(null)).willReturn(formList);
+
+        // when
+        List<FormSimpleResponse> returnedFormList = queryAllFormUseCase.execute(null, null, "total-score-asc");
+
+        // then
+        assertEquals(
+                Collections.min(formList, Comparator.comparingDouble(form -> form.getScore().getTotalScore()))
+                        .getScore()
+                        .getTotalScore(),
+                returnedFormList.get(0).getTotalScore()
+        );
 
         verify(formRepository, times(1)).findByStatus(null);
     }

--- a/src/test/java/com/bamdoliro/maru/application/form/SelectSecondPassUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/SelectSecondPassUseCaseTest.java
@@ -1,0 +1,100 @@
+package com.bamdoliro.maru.application.form;
+
+import com.bamdoliro.maru.domain.form.domain.Form;
+import com.bamdoliro.maru.domain.form.domain.type.FormStatus;
+import com.bamdoliro.maru.domain.form.service.AssignExaminationNumberService;
+import com.bamdoliro.maru.domain.form.service.CalculateFormScoreService;
+import com.bamdoliro.maru.domain.user.domain.User;
+import com.bamdoliro.maru.infrastructure.persistence.form.FormRepository;
+import com.bamdoliro.maru.infrastructure.persistence.user.UserRepository;
+import com.bamdoliro.maru.shared.constants.FixedNumber;
+import com.bamdoliro.maru.shared.fixture.FormFixture;
+import com.bamdoliro.maru.shared.fixture.UserFixture;
+import com.bamdoliro.maru.shared.util.RandomUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Comparator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Disabled
+@Slf4j
+@ActiveProfiles("test")
+@SpringBootTest
+public class SelectSecondPassUseCaseTest {
+
+    @Autowired
+    private SelectSecondPassUseCase selectSecondPassUseCase;
+
+    @Autowired
+    private SelectFirstPassUseCase selectFirstPassUseCase;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private FormRepository formRepository;
+
+    @Autowired
+    private CalculateFormScoreService calculateFormScoreService;
+
+    @Autowired
+    private AssignExaminationNumberService assignExaminationNumberService;
+
+    @BeforeEach
+    void setUp() {
+        List<User> userList = userRepository.saveAll(
+                UserFixture.generateUserList(FixedNumber.TOTAL * 2)
+        );
+        List<Form> formList = FormFixture.generateFormList(userList);
+        formList.forEach(form -> {
+            assignExaminationNumberService.execute(form);
+            form.receive();
+            calculateFormScoreService.execute(form);
+            formRepository.save(form);
+        });
+        selectFirstPassUseCase.execute();
+        List<Form> firstPassedFormList = formRepository.findByStatus(FormStatus.FIRST_PASSED);
+        firstPassedFormList.forEach(form -> {
+            if (form.getType().isMeister()) {
+                form.getScore().updateSecondRoundMeisterScore(RandomUtil.randomDouble(0, 100), RandomUtil.randomDouble(0, 100), RandomUtil.randomDouble(0, 100));
+            } else {
+                form.getScore().updateSecondRoundScore(RandomUtil.randomDouble(0, 100), RandomUtil.randomDouble(0, 100));
+            }
+            formRepository.save(form);
+        });
+    }
+
+    @Test
+    void 정상적으로_2차전형_합격자를_선발한다() {
+        selectSecondPassUseCase.execute();
+
+        Comparator<Form> comparator = Comparator
+                .comparing(Form::getType)
+                .thenComparing(form -> form.getScore().getTotalScore());
+
+        List<Form> formList = formRepository.findAll()
+                .stream()
+                .filter(form -> form.isPassedNow() || form.isFailedNow())
+                .sorted(comparator)
+                .toList();
+
+        formList.forEach(form -> {
+            log.info("====================");
+            log.info("id: {}", form.getId());
+            log.info("examinationNumber: {}", form.getExaminationNumber());
+            log.info("type: {}", form.getType());
+            log.info("score: {}", form.getScore().getTotalScore());
+            log.info("status: {}", form.getStatus());
+        });
+        int passedFormCount = (int)formList.stream().filter(Form::isPassedNow).count();
+        assertEquals(FixedNumber.TOTAL, passedFormCount);
+    }
+}

--- a/src/test/java/com/bamdoliro/maru/presentation/form/FormControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/presentation/form/FormControllerTest.java
@@ -8,7 +8,7 @@ import com.bamdoliro.maru.domain.form.exception.CannotUpdateNotRejectedFormExcep
 import com.bamdoliro.maru.domain.form.exception.FormAlreadySubmittedException;
 import com.bamdoliro.maru.domain.form.exception.FormNotFoundException;
 import com.bamdoliro.maru.domain.form.exception.InvalidFileException;
-import com.bamdoliro.maru.domain.form.exception.InvalidFromStatusException;
+import com.bamdoliro.maru.domain.form.exception.InvalidFormStatusException;
 import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.infrastructure.pdf.exception.FailedToExportPdfException;
 import com.bamdoliro.maru.infrastructure.s3.dto.response.UploadResponse;
@@ -1510,7 +1510,7 @@ class FormControllerTest extends RestDocsTestSupport {
 
         given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
-        willThrow(new InvalidFromStatusException()).given(generateAdmissionTicketUseCase).execute(user);
+        willThrow(new InvalidFormStatusException()).given(generateAdmissionTicketUseCase).execute(user);
 
         mockMvc.perform(get("/form/admission-ticket")
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())

--- a/src/test/java/com/bamdoliro/maru/presentation/form/FormControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/presentation/form/FormControllerTest.java
@@ -1348,7 +1348,7 @@ class FormControllerTest extends RestDocsTestSupport {
 
         given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
-        given(queryAllFormUseCase.execute(FormStatus.SUBMITTED, FormType.Category.REGULAR)).willReturn(responseList);
+        given(queryAllFormUseCase.execute(FormStatus.SUBMITTED, FormType.Category.REGULAR, null)).willReturn(responseList);
 
         mockMvc.perform(get("/form")
                         .param("status", FormStatus.SUBMITTED.name())
@@ -1374,7 +1374,7 @@ class FormControllerTest extends RestDocsTestSupport {
                         )
                 ));
 
-        verify(queryAllFormUseCase, times(1)).execute(FormStatus.SUBMITTED, FormType.Category.REGULAR);
+        verify(queryAllFormUseCase, times(1)).execute(FormStatus.SUBMITTED, FormType.Category.REGULAR, null);
     }
 
     @Test

--- a/src/test/java/com/bamdoliro/maru/shared/fixture/FormFixture.java
+++ b/src/test/java/com/bamdoliro/maru/shared/fixture/FormFixture.java
@@ -326,7 +326,7 @@ public class FormFixture {
     }
 
     private static FormType randomFormType() {
-        FormType[] values = {FormType.REGULAR, FormType.REGULAR, FormType.REGULAR, FormType.REGULAR, FormType.MEISTER_TALENT, FormType.MEISTER_TALENT, FormType.MEISTER_TALENT, FormType.MEISTER_TALENT, FormType.ONE_PARENT, FormType.MULTI_CHILDREN, FormType.SPECIAL_ADMISSION};
+        FormType[] values = {FormType.REGULAR, FormType.REGULAR, FormType.REGULAR, FormType.REGULAR, FormType.MEISTER_TALENT, FormType.MEISTER_TALENT, FormType.MEISTER_TALENT, FormType.MEISTER_TALENT, FormType.ONE_PARENT, FormType.MULTI_CHILDREN};
         return values[new Random().nextInt(values.length)];
     }
 

--- a/src/test/java/com/bamdoliro/maru/shared/util/ControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/shared/util/ControllerTest.java
@@ -12,32 +12,7 @@ import com.bamdoliro.maru.application.fair.CreateAdmissionFairUseCase;
 import com.bamdoliro.maru.application.fair.ExportAttendeeListUseCase;
 import com.bamdoliro.maru.application.fair.QueryFairDetailUseCase;
 import com.bamdoliro.maru.application.fair.QueryFairListUseCase;
-import com.bamdoliro.maru.application.form.ApproveFormUseCase;
-import com.bamdoliro.maru.application.form.DownloadSecondRoundScoreFormatUseCase;
-import com.bamdoliro.maru.application.form.DraftFormUseCase;
-import com.bamdoliro.maru.application.form.ExportFinalPassedFormUseCase;
-import com.bamdoliro.maru.application.form.ExportFirstRoundResultUseCase;
-import com.bamdoliro.maru.application.form.ExportFormUseCase;
-import com.bamdoliro.maru.application.form.ExportResultUseCase;
-import com.bamdoliro.maru.application.form.ExportSecondRoundResultUseCase;
-import com.bamdoliro.maru.application.form.GenerateAdmissionTicketUseCase;
-import com.bamdoliro.maru.application.form.PassOrFailFormUseCase;
-import com.bamdoliro.maru.application.form.QueryAllFormUseCase;
-import com.bamdoliro.maru.application.form.QueryDraftFormUseCase;
-import com.bamdoliro.maru.application.form.QueryFinalFormResultUseCase;
-import com.bamdoliro.maru.application.form.QueryFirstFormResultUseCase;
-import com.bamdoliro.maru.application.form.QueryFormStatusUseCase;
-import com.bamdoliro.maru.application.form.QueryFormUrlUseCase;
-import com.bamdoliro.maru.application.form.QueryFormUseCase;
-import com.bamdoliro.maru.application.form.QuerySubmittedFormUseCase;
-import com.bamdoliro.maru.application.form.ReceiveFormUseCase;
-import com.bamdoliro.maru.application.form.RejectFormUseCase;
-import com.bamdoliro.maru.application.form.SubmitFinalFormUseCase;
-import com.bamdoliro.maru.application.form.SubmitFormUseCase;
-import com.bamdoliro.maru.application.form.UpdateFormUseCase;
-import com.bamdoliro.maru.application.form.UpdateSecondRoundScoreUseCase;
-import com.bamdoliro.maru.application.form.UploadFormUseCase;
-import com.bamdoliro.maru.application.form.UploadIdentificationPictureUseCase;
+import com.bamdoliro.maru.application.form.*;
 import com.bamdoliro.maru.application.message.SendMessageUseCase;
 import com.bamdoliro.maru.application.notice.*;
 import com.bamdoliro.maru.application.question.CreateQuestionUseCase;
@@ -245,6 +220,9 @@ public abstract class ControllerTest {
 
     @MockBean
     protected QueryFormUrlUseCase queryFormUrlUseCase;
+
+    @MockBean
+    protected SelectSecondPassUseCase selectSecondPassUseCase;
 
     @MockBean
     protected SendMessageUseCase sendMessageUseCase;

--- a/src/test/java/com/bamdoliro/maru/shared/util/ControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/shared/util/ControllerTest.java
@@ -12,32 +12,7 @@ import com.bamdoliro.maru.application.fair.CreateAdmissionFairUseCase;
 import com.bamdoliro.maru.application.fair.ExportAttendeeListUseCase;
 import com.bamdoliro.maru.application.fair.QueryFairDetailUseCase;
 import com.bamdoliro.maru.application.fair.QueryFairListUseCase;
-import com.bamdoliro.maru.application.form.ApproveFormUseCase;
-import com.bamdoliro.maru.application.form.DownloadSecondRoundScoreFormatUseCase;
-import com.bamdoliro.maru.application.form.DraftFormUseCase;
-import com.bamdoliro.maru.application.form.ExportFinalPassedFormUseCase;
-import com.bamdoliro.maru.application.form.ExportFirstRoundResultUseCase;
-import com.bamdoliro.maru.application.form.ExportFormUseCase;
-import com.bamdoliro.maru.application.form.ExportResultUseCase;
-import com.bamdoliro.maru.application.form.ExportSecondRoundResultUseCase;
-import com.bamdoliro.maru.application.form.GenerateAdmissionTicketUseCase;
-import com.bamdoliro.maru.application.form.PassOrFailFormUseCase;
-import com.bamdoliro.maru.application.form.QueryAllFormUseCase;
-import com.bamdoliro.maru.application.form.QueryDraftFormUseCase;
-import com.bamdoliro.maru.application.form.QueryFinalFormResultUseCase;
-import com.bamdoliro.maru.application.form.QueryFirstFormResultUseCase;
-import com.bamdoliro.maru.application.form.QueryFormStatusUseCase;
-import com.bamdoliro.maru.application.form.QueryFormUrlUseCase;
-import com.bamdoliro.maru.application.form.QueryFormUseCase;
-import com.bamdoliro.maru.application.form.QuerySubmittedFormUseCase;
-import com.bamdoliro.maru.application.form.ReceiveFormUseCase;
-import com.bamdoliro.maru.application.form.RejectFormUseCase;
-import com.bamdoliro.maru.application.form.SubmitFinalFormUseCase;
-import com.bamdoliro.maru.application.form.SubmitFormUseCase;
-import com.bamdoliro.maru.application.form.UpdateFormUseCase;
-import com.bamdoliro.maru.application.form.UpdateSecondRoundScoreUseCase;
-import com.bamdoliro.maru.application.form.UploadFormUseCase;
-import com.bamdoliro.maru.application.form.UploadIdentificationPictureUseCase;
+import com.bamdoliro.maru.application.form.*;
 import com.bamdoliro.maru.application.message.SendMessageUseCase;
 import com.bamdoliro.maru.application.notice.CreateNoticeUseCase;
 import com.bamdoliro.maru.application.notice.DeleteNoticeUseCase;
@@ -246,6 +221,9 @@ public abstract class ControllerTest {
 
     @MockBean
     protected QueryFormUrlUseCase queryFormUrlUseCase;
+
+    @MockBean
+    protected SelectSecondPassUseCase selectSecondPassUseCase;
 
     @MockBean
     protected SendMessageUseCase sendMessageUseCase;

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,63 @@
+spring:
+  profiles:
+    active: test
+
+  data:
+    redis:
+      host:localhost
+      port:6379
+      timeout:6
+    h2:
+      console:
+        enabled: true
+        path: /h2-console
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:db;MODE=MYSQL
+    username: sa
+    password:
+  jpa:
+    generate-ddl: 'true'
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true
+
+
+  cloud:
+    aws:
+      s3:
+        bucket: ${BUCKET_NAME}
+      stack:
+        auto: false
+      region:
+        static: ${S3_REGION}
+      credentials:
+        instance-profile: true
+        access-key: ${S3_ACCESS_KEY}
+        secret-key: ${S3_SECRET_KEY}
+
+  logging:
+    level:
+      com.amazonaws.util.EC2MetadataUtils: error
+
+  servlet:
+    multipart:
+      max-file-size: 10MB
+
+jwt:
+  refresh-expiration-time: 1296000000 # 15일
+  access-expiration-time: 3600000 # 1시간
+  prefix: Bearer
+  secret-key: ${JWT_SECRET}
+
+neis:
+  key: ${NEIS_KEY}
+
+message:
+  api-key: ${MESSAGE_API_KEY}
+  api-secret: ${MESSAGE_API_SECRET}
+  api-domain: ${MESSAGE_API_DOMAIN}
+  from: ${MESSAGE_FROM}


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #98

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

>최종 합격을 최종 점수 순으로 자동으로 결정하는 기능을 만들었습니다.
>원서를 전체 조회할 때, 최종 점수 순으로 정렬하는 기능을 만들었습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- 최종 합격 자동 결정 API를 만들었습니다.
- 원서 전체 조회 시 정렬 파라미터를 추가했습니다.

<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)
SelectFirstPassUseCaseTest처럼 만들고 싶은데 테스트 프로필에서 h2 db가 작동하지 않아서... 도움 부탁드립니다 ㅠㅠㅠ
