### PR TITLE
fix(#105): 에러 메시지 수정

### DIFF
--- a/src/main/java/com/bamdoliro/maru/shared/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/bamdoliro/maru/shared/error/GlobalExceptionHandler.java
@@ -74,7 +74,7 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity
                 .status(GlobalErrorProperty.BAD_REQUEST.getStatus())
-                .body(new ErrorResponse(GlobalErrorProperty.BAD_REQUEST, e.getMessage()));
+                .body(new ErrorResponse(GlobalErrorProperty.BAD_REQUEST, e.getBindingResult().getFieldErrors().get(0).getDefaultMessage()));
     }
 
     @ExceptionHandler(FileSizeLimitExceededException.class)


### PR DESCRIPTION
- Request Body의 값을 잘못 넣었을 때 지정한 에러 메시지 대신 내부 에러 메시지 전체가 출력되는 오류를 해결했어요.

## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #105 

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> Request Body에 잘못된 값을 넣었을 때 서버의 에러 메시지가 그대로 출력되는 것을 해결했습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- MethodArgumentNotValidException이 발생했을 때 서버 에러메시지 대신 설정한 에러 메시지가 응답으로 나오도록 변경했습니다.


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [ ] 테스트를 완료했나요?
- [ ] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

Enum 유효성을 검증하기 위해서는 @JsonCreator를 사용해서 파라미터로 해당 enum 이외의 값이 전달되면 Validator로 null을 전달해서 오류를 발생시켜야 하는데, 상황에 따라서 enum 값에 null을 허용하는 경우(원서 전체 조회시 FormType)도 있고 아닌 경우(원서 제출시 FormType)도 있어서 이에 대한 처리가 어려워 포기했습니다.

대신에 서버 에러메시지가 그대로 응답에 포함되는 것은 해결했습니다.
