### PR TITLE
[개선] 입학원서 과목 목록 정렬

### DIFF
--- a/src/main/java/com/bamdoliro/maru/application/form/ExportFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/ExportFormUseCase.java
@@ -24,10 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.ByteArrayResource;
 
 import java.io.ByteArrayOutputStream;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -75,7 +72,12 @@ public class ExportFormUseCase {
         Map<String, List<Subject>> subjectMap = form.getGrade()
                 .getSubjectListValue()
                 .stream()
-                .collect(Collectors.groupingBy(Subject::getSubjectName));
+                .collect(Collectors.groupingBy(
+                        Subject::getSubjectName,
+                        LinkedHashMap::new,
+                        Collectors.toList()
+                ));
+
 
         subjectMap.forEach((key, values) -> {
             SubjectVO subject = new SubjectVO(key);
@@ -84,7 +86,7 @@ public class ExportFormUseCase {
                     subject.score = v.getOriginalScore();
                 } else {
                     try {
-                        SubjectVO.class.getField("achievementLevel" + v.toString())
+                        SubjectVO.class.getField("achievementLevel" + v)
                                 .set(subject, v.getAchievementLevel());
                     } catch (IllegalAccessException | NoSuchFieldException e) {
                         throw new RuntimeException(e);

--- a/src/main/java/com/bamdoliro/maru/application/form/ExportFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/ExportFormUseCase.java
@@ -4,7 +4,6 @@ import com.bamdoliro.maru.domain.form.domain.Form;
 import com.bamdoliro.maru.domain.form.domain.type.AchievementLevel;
 import com.bamdoliro.maru.domain.form.domain.value.Subject;
 import com.bamdoliro.maru.domain.form.domain.value.SubjectMap;
-import com.bamdoliro.maru.domain.form.exception.FormAlreadySubmittedException;
 import com.bamdoliro.maru.domain.form.service.FormFacade;
 import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.infrastructure.pdf.GeneratePdfService;
@@ -69,15 +68,25 @@ public class ExportFormUseCase {
 
     private List<SubjectVO> getSubjectList(Form form) {
         List<SubjectVO> value = new ArrayList<>();
+        List<String> careerElectiveCourses = List.of("음악", "미술", "체육");
         Map<String, List<Subject>> subjectMap = form.getGrade()
                 .getSubjectListValue()
                 .stream()
+                .filter(subject -> !careerElectiveCourses.contains(subject.getSubjectName()))
                 .collect(Collectors.groupingBy(
                         Subject::getSubjectName,
                         LinkedHashMap::new,
                         Collectors.toList()
                 ));
-
+        careerElectiveCourses.forEach(course -> {
+            List<Subject> subjects = form.getGrade().getSubjectListValue()
+                    .stream()
+                    .filter(subject -> course.equals(subject.getSubjectName()))
+                    .collect(Collectors.toList());
+            if (!subjects.isEmpty()) {
+                subjectMap.put(course, subjects);
+            }
+        });
 
         subjectMap.forEach((key, values) -> {
             SubjectVO subject = new SubjectVO(key);


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #123 

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 입학원서 pdf 저장 시 성적 일람표에서 과목 목록을 정렬했습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- 원서 pdf 저장 시 과목 목록을 입력한 순서대로 유지하도록 했습니다.
- 원서 pdf 저장 시 성적 일람표에서 진로 선택 과목은 맨 밑으로 위치하도록 했습니다.


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [ ] 테스트를 완료했나요?
- [ ] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

