### PR TITLE
[개선] 원서 전체 조회 정렬 옵션 추가

### DIFF
--- a/src/main/java/com/bamdoliro/maru/application/form/QueryAllFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/QueryAllFormUseCase.java
@@ -25,13 +25,14 @@ public class QueryAllFormUseCase {
                 .filter(form -> Objects.isNull(category) || form.getType().categoryEquals(category))
                 .toList());
 
-        if (sort != null && formList.stream().anyMatch(form -> form.getScore().getTotalScore() == null)) {
-            throw new MissingTotalScoreException();
-        }
-        if ("total-score-asc".equals(sort)) {
-            formList.sort(Comparator.comparing(form -> form.getScore().getTotalScore(), Comparator.naturalOrder()));
-        } else if ("total-score-desc".equals(sort)) {
-            formList.sort(Comparator.comparing(form -> form.getScore().getTotalScore(), Comparator.reverseOrder()));
+        if (sort != null) {
+            switch (sort) {
+                case "total-score-asc" ->
+                        formList.sort(Comparator.comparing(form -> form.getScore().getTotalScore(), Comparator.nullsLast(Comparator.naturalOrder())));
+                case "total-score-desc" ->
+                        formList.sort(Comparator.comparing(form -> form.getScore().getTotalScore(), Comparator.nullsLast(Comparator.reverseOrder())));
+                case "form-id" -> formList.sort(Comparator.comparing(Form::getId));
+            }
         }
 
         return formList.stream()

--- a/src/main/java/com/bamdoliro/maru/application/form/QueryAllFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/QueryAllFormUseCase.java
@@ -3,7 +3,6 @@ package com.bamdoliro.maru.application.form;
 import com.bamdoliro.maru.domain.form.domain.Form;
 import com.bamdoliro.maru.domain.form.domain.type.FormStatus;
 import com.bamdoliro.maru.domain.form.domain.type.FormType;
-import com.bamdoliro.maru.domain.form.exception.MissingTotalScoreException;
 import com.bamdoliro.maru.infrastructure.persistence.form.FormRepository;
 import com.bamdoliro.maru.presentation.form.dto.response.FormSimpleResponse;
 import com.bamdoliro.maru.shared.annotation.UseCase;

--- a/src/test/java/com/bamdoliro/maru/application/form/QueryAllFormUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/QueryAllFormUseCaseTest.java
@@ -170,4 +170,25 @@ class QueryAllFormUseCaseTest {
 
         verify(formRepository, times(1)).findByStatus(null);
     }
+
+    @Test
+    void 접수번호가_높은_순으로_조회한다() {
+        // given
+        List<Form> formList = List.of(
+                FormFixture.createForm(FormType.REGULAR),
+                FormFixture.createForm(FormType.SPECIAL_ADMISSION),
+                FormFixture.createForm(FormType.MEISTER_TALENT),
+                FormFixture.createForm(FormType.MULTI_CHILDREN)
+        );
+
+        given(formRepository.findByStatus(null)).willReturn(formList);
+
+        // when
+        List<FormSimpleResponse> returnedFormList = queryAllFormUseCase.execute(null, FormType.Category.SOCIAL_INTEGRATION, "form-id");
+
+        // then
+        assertEquals(1, returnedFormList.size());
+
+        verify(formRepository, times(1)).findByStatus(null);
+    }
 }

--- a/src/test/java/com/bamdoliro/maru/presentation/form/FormControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/presentation/form/FormControllerTest.java
@@ -1272,7 +1272,7 @@ class FormControllerTest extends RestDocsTestSupport {
                                         .description("<<form-type,원서 유형 (null인 경우 전체 조회)>>")
                                         .optional(),
                                 parameterWithName("sort")
-                                        .description("정렬 기준 (최종 점수 오름차순인 경우 total-score-asc, 최종 점수 내림차순인 경우 total-score-desc, null인 경우 수험번호 오름차순 조회)")
+                                        .description("정렬 기준 (total-score-asc인 경우 최종 점수 오름차순, total-score-desc인 경우 최종 점수 내림차순, form-id인 경우 접수 번호순, null인 경우 수험번호 오름차순 조회)")
                                         .optional()
                         )
                 ));


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #124 

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 원서 전체 조회 정렬을 수정했습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- 정렬 시 접수번호로 정렬을 할 수 있도록 추가했습니다.
- 최종 점수로 정렬 시 최종 점수가 null인 원서가 있어도 정렬이 되도록 수정했습니다.


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

