### PR TITLE
[버그] 엑셀로 지원자 명단을 추출할때 검정고시는 parseInt가 안되어 500 오류 발생

### DIFF
--- a/src/main/java/com/bamdoliro/maru/application/form/ExportFirstRoundResultUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/ExportFirstRoundResultUseCase.java
@@ -85,7 +85,7 @@ public class ExportFirstRoundResultUseCase {
             schoolCell.setCellStyle(defaultCellStyle);
 
             Cell schoolCodeCell = row.createCell(10);
-            schoolCodeCell.setCellValue(Integer.parseInt(form.getEducation().getSchool().getCode()));
+            schoolCodeCell.setCellValue(form.getEducation().getSchool().getCode());
             schoolCodeCell.setCellStyle(defaultCellStyle);
 
             Cell subjectGradeScoreCell = row.createCell(11);

--- a/src/main/java/com/bamdoliro/maru/application/form/ExportResultUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/ExportResultUseCase.java
@@ -77,7 +77,7 @@ public class ExportResultUseCase {
             schoolCell.setCellStyle(defaultCellStyle);
 
             Cell schoolCodeCell = row.createCell(10);
-            schoolCodeCell.setCellValue(Integer.parseInt(form.getEducation().getSchool().getCode()));
+            schoolCodeCell.setCellValue(form.getEducation().getSchool().getCode());
             schoolCodeCell.setCellStyle(defaultCellStyle);
 
             Cell subjectGradeScoreCell = row.createCell(11);

--- a/src/main/java/com/bamdoliro/maru/application/form/ExportSecondRoundResultUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/ExportSecondRoundResultUseCase.java
@@ -82,7 +82,7 @@ public class ExportSecondRoundResultUseCase {
             schoolCell.setCellStyle(defaultCellStyle);
 
             Cell schoolCodeCell = row.createCell(9);
-            schoolCodeCell.setCellValue(Integer.parseInt(form.getEducation().getSchool().getCode()));
+            schoolCodeCell.setCellValue(form.getEducation().getSchool().getCode());
             schoolCodeCell.setCellStyle(defaultCellStyle);
 
             Cell subjectGradeScoreCell = row.createCell(10);


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #134

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

>  전체, 1차합격, 2차합격자 명단 추출시 학교 코드는 String으로 넣게 변경했습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- ExportResultUseCase, ExportFirstRoundResultUseCase, ExportSecondRoundResultUseCase에 있는 parseInt()를 제거했어요.


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

