### PR TITLE
[개선] 공지사항 조회시 수정일이 나오도록 변경

### DIFF
--- a/src/main/java/com/bamdoliro/maru/presentation/notice/dto/response/NoticeSimpleResponse.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/notice/dto/response/NoticeSimpleResponse.java
@@ -10,11 +10,11 @@ public class NoticeSimpleResponse {
 
     private final Long id;
     private final String title;
-    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
 
     public NoticeSimpleResponse(Notice notice) {
         this.id = notice.getId();
         this.title = notice.getTitle();
-        this.createdAt = notice.getCreatedAt();
+        this.updatedAt = notice.getUpdatedAt();
     }
 }


### PR DESCRIPTION
- NoticeSimpleResponse에서 updatedAt을 반환하도록 변경했어요.

## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #146 

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 공지사항 전체 조회시 수정일이 나오도록 만들었습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- 전체 조회 Dto를 수정했습니다.


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

