### PR TITLE
[개선] 원서 반려시 재제출 가능하도록 변경

### DIFF
--- a/src/main/java/com/bamdoliro/maru/application/form/SubmitFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/SubmitFormUseCase.java
@@ -40,6 +40,10 @@ public class SubmitFormUseCase {
 
     private void validateOnlyOneFormPerUser(User user) {
         if (formRepository.existsByUserId(user.getId())) {
+            if (formRepository.findByUser(user).get().isRejected()) {
+                formRepository.deleteByUser(user);
+                return;
+            }
             throw new FormAlreadySubmittedException();
         }
     }

--- a/src/main/java/com/bamdoliro/maru/application/form/SubmitFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/SubmitFormUseCase.java
@@ -11,6 +11,8 @@ import com.bamdoliro.maru.shared.annotation.UseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @RequiredArgsConstructor
 @UseCase
 public class SubmitFormUseCase {
@@ -39,9 +41,10 @@ public class SubmitFormUseCase {
     }
 
     private void validateOnlyOneFormPerUser(User user) {
-        if (formRepository.existsByUserId(user.getId())) {
-            if (formRepository.findByUser(user).get().isRejected()) {
-                formRepository.deleteByUser(user);
+        Optional<Form> form = formRepository.findByUser(user);
+        if (form.isPresent()) {
+            if (form.get().isRejected()) {
+                formRepository.delete(form.get());
                 return;
             }
             throw new FormAlreadySubmittedException();

--- a/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepository.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepository.java
@@ -14,6 +14,8 @@ public interface FormRepository extends JpaRepository<Form, Long>, FormRepositor
 
     Optional<Form> findByUser(User user);
 
+    void deleteByUser(User user);
+
     @Query("SELECT MAX(f.examinationNumber) " +
             "FROM Form f " +
             "WHERE f.examinationNumber BETWEEN :minValue AND :maxValue")

--- a/src/test/java/com/bamdoliro/maru/application/form/SubmitFormUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/SubmitFormUseCaseTest.java
@@ -47,7 +47,8 @@ class SubmitFormUseCaseTest {
         SubmitFormRequest request = FormFixture.createFormRequest(FormType.REGULAR);
         User user = UserFixture.createUser();
 
-        given(formRepository.existsByUserId(user.getId())).willReturn(false);
+        given(formRepository.findByUser(user)).willReturn(Optional.empty());
+
         willDoNothing().given(assignExaminationNumberService).execute(any(Form.class));
         willDoNothing().given(calculateFormScoreService).execute(any(Form.class));
 
@@ -56,7 +57,7 @@ class SubmitFormUseCaseTest {
 
         // then
 
-        verify(formRepository, times(1)).existsByUserId(user.getId());
+        verify(formRepository, times(1)).findByUser(user);
         verify(calculateFormScoreService, times(1)).execute(any(Form.class));
         verify(assignExaminationNumberService, times(1)).execute(any(Form.class));
         verify(formRepository, times(1)).save(any(Form.class));
@@ -69,16 +70,15 @@ class SubmitFormUseCaseTest {
         User user = UserFixture.createUser();
         Form form = FormFixture.createForm(FormType.REGULAR);
 
-        given(formRepository.existsByUserId(user.getId())).willReturn(true);
         given(formRepository.findByUser(user)).willReturn(Optional.of(form));
 
         // when and then
         assertThrows(FormAlreadySubmittedException.class, () -> submitFormUseCase.execute(user, request));
 
-        verify(formRepository, times(1)).existsByUserId(user.getId());
+        verify(formRepository, times(1)).findByUser(user);
         verify(calculateFormScoreService, never()).execute(any(Form.class));
         verify(assignExaminationNumberService, never()).execute(any(Form.class));
-        verify(formRepository, never()).deleteByUser(any(User.class));
+        verify(formRepository, never()).delete(any(Form.class));
         verify(formRepository, never()).save(any(Form.class));
     }
 
@@ -90,17 +90,16 @@ class SubmitFormUseCaseTest {
         Form form = FormFixture.createForm(FormType.REGULAR);
         form.reject();
 
-        given(formRepository.existsByUserId(user.getId())).willReturn(true);
         given(formRepository.findByUser(user)).willReturn(Optional.of(form));
 
         //when
         submitFormUseCase.execute(user, request);
 
         //then
-        verify(formRepository, times(1)).existsByUserId(user.getId());
+        verify(formRepository, times(1)).findByUser(user);
         verify(calculateFormScoreService, times(1)).execute(any(Form.class));
         verify(assignExaminationNumberService, times(1)).execute(any(Form.class));
-        verify(formRepository, times(1)).deleteByUser(any(User.class));
+        verify(formRepository, times(1)).delete(any(Form.class));
         verify(formRepository, times(1)).save(any(Form.class));
     }
 }


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #151

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 원서가 반려될 시 초안 재제출 기능을 만들었습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- submitFormUseCase의 검증 로직을 변경했습니다.


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

