### PR TITLE
[버그] 최종 합격자 엑셀 추출시 아무것도 나오지 않는 오류 발생

### DIFF
--- a/src/main/java/com/bamdoliro/maru/application/form/ExportFinalPassedFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/ExportFinalPassedFormUseCase.java
@@ -27,7 +27,7 @@ public class ExportFinalPassedFormUseCase {
     private final XlsxService xlsxService;
 
     public Resource execute() throws IOException {
-        List<Form> formList = formFacade.getSortedFormList(FormStatus.PASSED);
+        List<Form> formList = formFacade.getSortedFormList(FormStatus.ENTERED);
         Workbook workbook = xlsxService.openTemplate("최종합격자");
         Sheet sheet = workbook.getSheetAt(0);
 


### PR DESCRIPTION
- 시간이 급하여 최종합격자 엑셀 추출 status를 PASSED에서 ENTERED를 가져오는 것으로 변경하였습니다.

## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #169

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 최종합격자 엑셀 추출 API를 수정하였습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- ExportFinalPassedFormUseCase에서 Facade를 호출할때 ENTERED를 인자값으로 전달하였습니다.


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

