### PR TITLE
[버그] querydsl 정렬 오류

### DIFF
--- a/src/main/java/com/bamdoliro/maru/application/analysis/QuerySchoolStatusUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/analysis/QuerySchoolStatusUseCase.java
@@ -1,11 +1,13 @@
 package com.bamdoliro.maru.application.analysis;
 
+import com.bamdoliro.maru.domain.form.domain.Form;
 import com.bamdoliro.maru.infrastructure.persistence.form.FormRepository;
 import com.bamdoliro.maru.presentation.analysis.dto.request.SchoolStatusRequest;
 import com.bamdoliro.maru.presentation.analysis.dto.response.SchoolStatusResponse;
 import com.bamdoliro.maru.shared.annotation.UseCase;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Comparator;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -22,12 +24,14 @@ public class QuerySchoolStatusUseCase {
             return formRepository.findSchoolByAddress(request.getStatusList(), keyword)
                     .stream()
                     .map(SchoolStatusResponse::new)
+                    .sorted(Comparator.comparing(SchoolStatusResponse::getApplicantName))
                     .toList();
         }
 
         return formRepository.findNotBusanSchool(request.getStatusList())
                 .stream()
                 .map(SchoolStatusResponse::new)
+                .sorted(Comparator.comparing(SchoolStatusResponse::getApplicantName))
                 .toList();
     }
 }

--- a/src/main/java/com/bamdoliro/maru/application/form/QueryAllFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/QueryAllFormUseCase.java
@@ -32,6 +32,8 @@ public class QueryAllFormUseCase {
                         formList.sort(Comparator.comparing(form -> form.getScore().getTotalScore(), Comparator.nullsLast(Comparator.reverseOrder())));
                 case "form-id" -> formList.sort(Comparator.comparing(Form::getId));
             }
+        } else {
+            formList.sort(Comparator.comparing(Form::getExaminationNumber));
         }
 
         return formList.stream()

--- a/src/main/java/com/bamdoliro/maru/application/form/UpdateSecondRoundScoreUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/UpdateSecondRoundScoreUseCase.java
@@ -35,6 +35,7 @@ public class UpdateSecondRoundScoreUseCase {
         Sheet sheet = workbook.getSheetAt(0);
 
         List<Form> formList = formRepository.findByStatus(FormStatus.FIRST_PASSED);
+        formList.sort(Comparator.comparing(Form::getExaminationNumber));
         List<SecondScoreVo> secondScoreVoList = getSecondScoreVoList(sheet);
         validateList(formList, secondScoreVoList);
 

--- a/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepositoryImpl.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepositoryImpl.java
@@ -26,7 +26,6 @@ public class FormRepositoryImpl implements FormRepositoryCustom {
         return queryFactory
                 .selectFrom(form)
                 .where(eqStatus(status))
-                .orderBy(form.examinationNumber.asc())
                 .fetch();
     }
 
@@ -327,7 +326,6 @@ public class FormRepositoryImpl implements FormRepositoryCustom {
                 .where(form.education.school.address.contains(keyword)
                         .or(form.education.school.location.eq(keyword))
                         .and(form.status.in(round)))
-                .orderBy(form.applicant.name.asc())
                 .fetch();
     }
 
@@ -341,7 +339,6 @@ public class FormRepositoryImpl implements FormRepositoryCustom {
                 ))
                 .from(form)
                 .where(form.education.school.location.eq("부산광역시").not())
-                .orderBy(form.applicant.name.asc())
                 .fetch();
     }
 }

--- a/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepositoryImpl.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepositoryImpl.java
@@ -34,7 +34,6 @@ public class FormRepositoryImpl implements FormRepositoryCustom {
         return queryFactory
                 .selectFrom(form)
                 .where(eqType(type))
-                .orderBy(form.examinationNumber.asc())
                 .fetch();
     }
 
@@ -45,7 +44,6 @@ public class FormRepositoryImpl implements FormRepositoryCustom {
         return queryFactory
                 .selectFrom(form)
                 .where(form.type.in(matchingFormTypes))
-                .orderBy(form.examinationNumber.asc())
                 .fetch();
     }
 
@@ -56,7 +54,6 @@ public class FormRepositoryImpl implements FormRepositoryCustom {
         return queryFactory
                 .selectFrom(form)
                 .where(form.originalType.in(matchingFormTypes))
-                .orderBy(form.examinationNumber.asc())
                 .fetch();
     }
 
@@ -202,7 +199,6 @@ public class FormRepositoryImpl implements FormRepositoryCustom {
                 .where(form.status.eq(FormStatus.FIRST_PASSED)
                         .or(form.status.eq(FormStatus.FIRST_FAILED))
                 )
-                .orderBy(form.examinationNumber.asc())
                 .fetch();
     }
 
@@ -245,7 +241,6 @@ public class FormRepositoryImpl implements FormRepositoryCustom {
                 .where(form.status.eq(FormStatus.FAILED)
                         .or(form.status.eq(FormStatus.PASSED))
                 )
-                .orderBy(form.examinationNumber.asc())
                 .fetch();
     }
 
@@ -268,7 +263,6 @@ public class FormRepositoryImpl implements FormRepositoryCustom {
                 ))
                 .from(form)
                 .where(form.id.in(idList))
-                .orderBy(form.examinationNumber.asc())
                 .fetch();
     }
 
@@ -347,7 +341,6 @@ public class FormRepositoryImpl implements FormRepositoryCustom {
         return queryFactory
                 .select(form.examinationNumber)
                 .from(form)
-                .orderBy(form.examinationNumber.desc())
                 .fetch();
     }
 }

--- a/src/test/java/com/bamdoliro/maru/application/form/QueryAllFormUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/QueryAllFormUseCaseTest.java
@@ -40,6 +40,8 @@ class QueryAllFormUseCaseTest {
                 FormFixture.createForm(FormType.MULTI_CHILDREN)
         );
 
+        formList.forEach(form -> form.assignExaminationNumber(1001L));
+
         given(formRepository.findByStatus(null)).willReturn(formList);
 
         // when
@@ -61,6 +63,8 @@ class QueryAllFormUseCaseTest {
                 FormFixture.createForm(FormType.MULTI_CHILDREN)
         );
 
+        formList.forEach(form -> form.assignExaminationNumber(1001L));
+
         given(formRepository.findByStatus(null)).willReturn(formList);
 
         // when
@@ -81,6 +85,8 @@ class QueryAllFormUseCaseTest {
                 FormFixture.createForm(FormType.MEISTER_TALENT),
                 FormFixture.createForm(FormType.MULTI_CHILDREN)
         );
+
+        formList.forEach(form -> form.assignExaminationNumber(1001L));
 
         given(formRepository.findByStatus(null)).willReturn(formList);
 


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #178 

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 정렬 로직을 수정하였습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- querydsl로 수행하던 정렬을 usecase에서 하도록 변경했습니다.
- QueryAllFormUseCase, QuerySchoolStatusUseCase, UpdateSecondRoundScoreUseCase 에서 정렬을 수행하도록 변경했습니다.
- FormRepositoryImpl 에서 orderBy() 메서드를 전부 제거했습니다.


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

