### PR TITLE
[개선] AWS S3 Presigned URL 파일 형식, 크기 제한

### DIFF
--- a/src/docs/asciidoc/form.adoc
+++ b/src/docs/asciidoc/form.adoc
@@ -296,9 +296,6 @@ include::{snippets}/form-controller-test/증명_사진을_업로드한다/http-r
 ===== 서버 문제로 업로드에 실패한 경우
 include::{snippets}/form-controller-test/증명_사진_업로드가_실패한다/http-response.adoc[]
 
-===== 사진 크기가 규격과 다른 경우
-include::{snippets}/form-controller-test/증명_사진을_업로드할_때_사진_크기가_다르면_에러가_발생한다/http-response.adoc[]
-
 ===== 빈 파일인 경우
 include::{snippets}/form-controller-test/증명_사진을_업로드할_때_파일이_비었으면_에러가_발생한다/http-response.adoc[]
 

--- a/src/docs/asciidoc/notice.adoc
+++ b/src/docs/asciidoc/notice.adoc
@@ -3,6 +3,9 @@
 === 공지사항 파일 업로드
 어드민 권한을 가진 사용자가 공지사항에 들어갈 파일을 업로드할 수 있습니다.
 
+모든 형식의 이미지, pdf, docx, pptx, xlsx, hwp 파일을 업로드할 수 있습니다.
+hwp 파일을 업로드할 때는 미디어 타입을 application/octet-stream으로 업로드 해야합니다.
+
 ==== 요청 형식
 
 ===== Request Header

--- a/src/main/java/com/bamdoliro/maru/application/notice/UploadFileUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/notice/UploadFileUseCase.java
@@ -22,11 +22,21 @@ public class UploadFileUseCase {
         validateFileCount(metadataList);
 
         return metadataList.stream()
-                .map(metadata1 -> {
-                    String fileName = UUID.randomUUID() + "_" + metadata1.getFileName();
+                .map(metadata -> {
+                    String fileName = UUID.randomUUID() + "_" + metadata.getFileName();
                     return new UploadFileResponse(
-                            fileService.getPresignedUrl(FolderConstant.NOTICE_FILE, fileName, metadata1, metadata2 ->
-                                    DefaultFileValidator.validate(metadata2, Set.of(MediaType.ALL))),
+                            fileService.getPresignedUrl(FolderConstant.NOTICE_FILE, fileName, metadata, metadata1 -> {
+                                MediaType image = MediaType.parseMediaType("image/*");
+                                MediaType docx = MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+                                MediaType pptx = MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.presentationml.presentation");
+                                MediaType xlsx = MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+
+                                DefaultFileValidator.validate(metadata1, Set.of(
+                                        image,
+                                        MediaType.APPLICATION_OCTET_STREAM, MediaType.APPLICATION_PDF,
+                                        docx, pptx, xlsx
+                                ));
+                            }),
                             fileName
                     );
                 })

--- a/src/main/java/com/bamdoliro/maru/infrastructure/s3/FileService.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/s3/FileService.java
@@ -38,9 +38,9 @@ public class FileService {
         return request != null ? amazonS3Client.generatePresignedUrl(request).toString() : null;
     }
 
-    public UrlResponse getPresignedUrl(String folder, String fileName, FileMetadata request, FileValidator validator) {
+    public UrlResponse getPresignedUrl(String folder, String fileName, FileMetadata metadata, FileValidator validator) {
         return new UrlResponse(
-                getUploadPresignedUrl(folder, fileName, request, validator),
+                getUploadPresignedUrl(folder, fileName, metadata, validator),
                 getDownloadPresignedUrl(folder, fileName)
         );
     }

--- a/src/main/java/com/bamdoliro/maru/infrastructure/s3/exception/error/S3ErrorProperty.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/s3/exception/error/S3ErrorProperty.java
@@ -16,7 +16,7 @@ public enum S3ErrorProperty implements ErrorProperty {
     FILE_SIZE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "최대 %dMB의 파일까지만 업로드할 수 있습니다."),
     MEDIA_TYPE_MISMATCH(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "파일 형식이 다릅니다."),
     INVALID_MEDIA_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "파일 형식이 유효하지 않습니다."),
-    FILE_COUNT_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "최대 %d개의 파일까지만 업로드할 수 있습니다.")
+    FILE_COUNT_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "1~%d개의 파일까지만 업로드할 수 있습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/bamdoliro/maru/infrastructure/s3/validator/DefaultFileValidator.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/s3/validator/DefaultFileValidator.java
@@ -30,7 +30,7 @@ public class DefaultFileValidator {
     public static void validate(FileMetadata metadata, Set<MediaType> allowedTypes) {
         try {
             MediaType mediaType = MediaType.parseMediaType(metadata.getMediaType());
-            if (allowedTypes.stream().anyMatch(allowedType -> allowedType.includes(mediaType))) {
+            if (allowedTypes.stream().noneMatch(allowedType -> allowedType.includes(mediaType))) {
                 throw new MediaTypeMismatchException();
             }
         } catch (org.springframework.http.InvalidMediaTypeException e) {

--- a/src/main/java/com/bamdoliro/maru/infrastructure/s3/validator/FileValidator.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/s3/validator/FileValidator.java
@@ -8,7 +8,7 @@ public interface FileValidator {
     void customValidate(FileMetadata request);
 
     default void validate(FileMetadata request) {
-        if (request.getFileName().isBlank() || request.getFileName().lastIndexOf(".") == -1) {
+        if (request.getFileName().isBlank() || request.getFileName().lastIndexOf(".") == -1 || request.getFileSize() <= 0) {
             throw new EmptyFileException();
         }
 

--- a/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
@@ -164,7 +164,6 @@ public class FormController {
         updateFormUseCase.execute(user, formId, request);
     }
 
-    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping( "/identification-picture")
     public SingleCommonResponse<UrlResponse> uploadIdentificationPicture(
             @AuthenticationPrincipal(authority = Authority.USER) User user,
@@ -175,7 +174,6 @@ public class FormController {
         );
     }
 
-    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/form-document")
     public SingleCommonResponse<UrlResponse> uploadFormDocument(
             @AuthenticationPrincipal(authority = Authority.USER) User user,

--- a/src/test/java/com/bamdoliro/maru/presentation/form/FormControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/presentation/form/FormControllerTest.java
@@ -894,16 +894,16 @@ class FormControllerTest extends RestDocsTestSupport {
 
         given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
-        given(uploadIdentificationPictureUseCase.execute(user, metadata)).willReturn(SharedFixture.createIdentificationPictureUrlResponse());
+        given(uploadIdentificationPictureUseCase.execute(any(User.class), any(FileMetadata.class))).willReturn(SharedFixture.createIdentificationPictureUrlResponse());
 
-        mockMvc.perform(multipart("/form/identification-picture")
+        mockMvc.perform(post("/form/identification-picture")
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(toJson(metadata))
                 )
 
-                .andExpect(status().isCreated())
+                .andExpect(status().isOk())
 
                 .andDo(restDocs.document(
                         requestHeaders(
@@ -936,7 +936,7 @@ class FormControllerTest extends RestDocsTestSupport {
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
         doThrow(new FailedToSaveException()).when(uploadIdentificationPictureUseCase).execute(any(User.class), any(FileMetadata.class));
 
-        mockMvc.perform(multipart("/form/identification-picture")
+        mockMvc.perform(post("/form/identification-picture")
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -944,6 +944,33 @@ class FormControllerTest extends RestDocsTestSupport {
                 )
 
                 .andExpect(status().isInternalServerError())
+
+                .andDo(restDocs.document());
+
+        verify(uploadIdentificationPictureUseCase, times(1)).execute(any(User.class), any(FileMetadata.class));
+    }
+
+    @Test
+    void 증명_사진을_업로드할_때_파일이_비었으면_에러가_발생한다() throws Exception {
+        User user = UserFixture.createUser();
+        FileMetadata metadata = new FileMetadata(
+                "identification-picture.png",
+                MediaType.IMAGE_PNG_VALUE,
+                0L
+        );
+
+        given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
+        given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
+        doThrow(new EmptyFileException()).when(uploadIdentificationPictureUseCase).execute(any(User.class), any(FileMetadata.class));
+
+        mockMvc.perform(post("/form/identification-picture")
+                        .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(metadata))
+                )
+
+                .andExpect(status().isBadRequest())
 
                 .andDo(restDocs.document());
 
@@ -963,7 +990,7 @@ class FormControllerTest extends RestDocsTestSupport {
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
         doThrow(new FileSizeLimitExceededException(2)).when(uploadIdentificationPictureUseCase).execute(any(User.class), any(FileMetadata.class));
 
-        mockMvc.perform(multipart("/form/identification-picture")
+        mockMvc.perform(post("/form/identification-picture")
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -990,7 +1017,7 @@ class FormControllerTest extends RestDocsTestSupport {
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
         doThrow(new MediaTypeMismatchException()).when(uploadIdentificationPictureUseCase).execute(any(User.class), any(FileMetadata.class));
 
-        mockMvc.perform(multipart("/form/identification-picture")
+        mockMvc.perform(post("/form/identification-picture")
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -1015,16 +1042,16 @@ class FormControllerTest extends RestDocsTestSupport {
 
         given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
-        given(uploadFormUseCase.execute(user, metadata)).willReturn(SharedFixture.createFormUrlResponse());
+        given(uploadFormUseCase.execute(any(User.class), any(FileMetadata.class))).willReturn(SharedFixture.createFormUrlResponse());
 
-        mockMvc.perform(multipart("/form/form-document")
+        mockMvc.perform(post("/form/form-document")
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(toJson(metadata))
                 )
 
-                .andExpect(status().isCreated())
+                .andExpect(status().isOk())
 
                 .andDo(restDocs.document(
                         requestHeaders(
@@ -1057,7 +1084,7 @@ class FormControllerTest extends RestDocsTestSupport {
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
         doThrow(new FailedToSaveException()).when(uploadFormUseCase).execute(any(User.class), any(FileMetadata.class));
 
-        mockMvc.perform(multipart("/form/form-document")
+        mockMvc.perform(post("/form/form-document")
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -1065,6 +1092,33 @@ class FormControllerTest extends RestDocsTestSupport {
                 )
 
                 .andExpect(status().isInternalServerError())
+
+                .andDo(restDocs.document());
+
+        verify(uploadFormUseCase, times(1)).execute(any(User.class), any(FileMetadata.class));
+    }
+
+    @Test
+    void 원서_서류를_업로드할_때_파일이_비었으면_에러가_발생한다() throws Exception {
+        User user = UserFixture.createUser();
+        FileMetadata metadata = new FileMetadata(
+                "form.pdf",
+                MediaType.APPLICATION_PDF_VALUE,
+                0L
+        );
+
+        given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
+        given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
+        doThrow(new EmptyFileException()).when(uploadFormUseCase).execute(any(User.class), any(FileMetadata.class));
+
+        mockMvc.perform(post("/form/form-document")
+                        .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(metadata))
+                )
+
+                .andExpect(status().isBadRequest())
 
                 .andDo(restDocs.document());
 
@@ -1084,7 +1138,7 @@ class FormControllerTest extends RestDocsTestSupport {
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
         doThrow(new FileSizeLimitExceededException(20)).when(uploadFormUseCase).execute(any(User.class), any(FileMetadata.class));
 
-        mockMvc.perform(multipart("/form/form-document")
+        mockMvc.perform(post("/form/form-document")
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -1111,7 +1165,7 @@ class FormControllerTest extends RestDocsTestSupport {
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
         doThrow(new MediaTypeMismatchException()).when(uploadFormUseCase).execute(any(User.class), any(FileMetadata.class));
 
-        mockMvc.perform(multipart("/form/form-document")
+        mockMvc.perform(post("/form/form-document")
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -1205,9 +1259,9 @@ class FormControllerTest extends RestDocsTestSupport {
 
         given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
-        given(uploadAdmissionAndPledgeUseCase.execute(user, metadata)).willReturn(SharedFixture.createAdmissionAndPledgeUrlResponse());
+        given(uploadAdmissionAndPledgeUseCase.execute(any(User.class), any(FileMetadata.class))).willReturn(SharedFixture.createAdmissionAndPledgeUrlResponse());
 
-        mockMvc.perform(multipart("/form/admission-and-pledge")
+        mockMvc.perform(post("/form/admission-and-pledge")
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -1247,7 +1301,7 @@ class FormControllerTest extends RestDocsTestSupport {
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
         doThrow(new InvalidFormStatusException()).when(uploadAdmissionAndPledgeUseCase).execute(any(User.class), any(FileMetadata.class));
 
-        mockMvc.perform(multipart("/form/admission-and-pledge")
+        mockMvc.perform(post("/form/admission-and-pledge")
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -1274,7 +1328,7 @@ class FormControllerTest extends RestDocsTestSupport {
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
         doThrow(new FailedToSaveException()).when(uploadAdmissionAndPledgeUseCase).execute(any(User.class), any(FileMetadata.class));
 
-        mockMvc.perform(multipart("/form/admission-and-pledge")
+        mockMvc.perform(post("/form/admission-and-pledge")
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -1301,7 +1355,7 @@ class FormControllerTest extends RestDocsTestSupport {
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
         doThrow(new FileSizeLimitExceededException(20)).when(uploadAdmissionAndPledgeUseCase).execute(any(User.class), any(FileMetadata.class));
 
-        mockMvc.perform(multipart("/form/admission-and-pledge")
+        mockMvc.perform(post("/form/admission-and-pledge")
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -1328,7 +1382,7 @@ class FormControllerTest extends RestDocsTestSupport {
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
         doThrow(new MediaTypeMismatchException()).when(uploadAdmissionAndPledgeUseCase).execute(any(User.class), any(FileMetadata.class));
 
-        mockMvc.perform(multipart("/form/admission-and-pledge")
+        mockMvc.perform(post("/form/admission-and-pledge")
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/bamdoliro/maru/presentation/notice/NoticeControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/presentation/notice/NoticeControllerTest.java
@@ -316,7 +316,7 @@ class NoticeControllerTest extends RestDocsTestSupport {
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
         given(uploadFileUseCase.execute(anyList())).willThrow(new FailedToSaveException());
 
-        mockMvc.perform(multipart("/notice/file")
+        mockMvc.perform(post("/notice/file")
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #173 

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 공지사항 파일 업로드와 테스트 코드를 개선했습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- XSS 공격 방지를 위해서 공지사항에 업로드 가능한 파일 형식을 제한했습니다.
- 용량이 0바이트일 경우 에러가 나도록 했습니다.
- 증명사진, 원서 서류, 입학 등록원 업로드 테스트에서 Response Body가 null인 오류를 해결했습니다.


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

