### PR TITLE
[개선] 반려시 원서 재제출 기능 수정

### DIFF
--- a/src/main/java/com/bamdoliro/maru/application/form/SubmitFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/SubmitFormUseCase.java
@@ -43,10 +43,6 @@ public class SubmitFormUseCase {
     private void validateOnlyOneFormPerUser(User user) {
         Optional<Form> form = formRepository.findByUser(user);
         if (form.isPresent()) {
-            if (form.get().isRejected()) {
-                formRepository.delete(form.get());
-                return;
-            }
             throw new FormAlreadySubmittedException();
         }
     }

--- a/src/test/java/com/bamdoliro/maru/application/form/SubmitFormUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/SubmitFormUseCaseTest.java
@@ -81,25 +81,4 @@ class SubmitFormUseCaseTest {
         verify(formRepository, never()).delete(any(Form.class));
         verify(formRepository, never()).save(any(Form.class));
     }
-
-    @Test
-    void 원서를_제출할_때_이미_제출한_원서가_반려상태면_다시_작성한다() {
-        //given
-        SubmitFormRequest request = FormFixture.createFormRequest(FormType.REGULAR);
-        User user = UserFixture.createUser();
-        Form form = FormFixture.createForm(FormType.REGULAR);
-        form.reject();
-
-        given(formRepository.findByUser(user)).willReturn(Optional.of(form));
-
-        //when
-        submitFormUseCase.execute(user, request);
-
-        //then
-        verify(formRepository, times(1)).findByUser(user);
-        verify(calculateFormScoreService, times(1)).execute(any(Form.class));
-        verify(assignExaminationNumberService, times(1)).execute(any(Form.class));
-        verify(formRepository, times(1)).delete(any(Form.class));
-        verify(formRepository, times(1)).save(any(Form.class));
-    }
 }

--- a/src/test/java/com/bamdoliro/maru/application/form/UpdateSecondRoundScoreUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/UpdateSecondRoundScoreUseCaseTest.java
@@ -23,6 +23,7 @@ import org.springframework.test.context.ActiveProfiles;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -83,7 +84,9 @@ class UpdateSecondRoundScoreUseCaseTest {
 
 
         // then
-        List<Form> formList = formRepository.findByStatus(FormStatus.FIRST_PASSED);
+        List<Form> formList = formRepository.findByStatus(FormStatus.FIRST_PASSED).stream()
+                .sorted(Comparator.comparing(Form::getExaminationNumber))
+                .toList();
         assertEquals(3, formList.size());
         assertNull(formList.get(0).getScore().getCodingTestScore());
         assertEquals(20, formList.get(1).getScore().getCodingTestScore());


### PR DESCRIPTION
- SubmitFormUseCase 내에 있는 반려시 제재출 로직을 제거했어요.
- SubmitFormUseCaseTest에서 제재출 테스트 로직을 제거했어요.

## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #159

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> SubmitFormStatus에서 재제출 메서드를 제거했습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- SubmitFormStatus에서 재제출 메서드를 제거했습니다.
- 테스트를 제거했습니다.
- 기존에 만들어놨던 UpdateFormUseCase를 사용하게 변경하였습니다.


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

