### PR TITLE
[개선] 어드민 페이지 전형 필터링 개선

### DIFF
--- a/src/main/java/com/bamdoliro/maru/application/form/QueryAllFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/QueryAllFormUseCase.java
@@ -19,9 +19,9 @@ public class QueryAllFormUseCase {
 
     private final FormRepository formRepository;
 
-    public List<FormSimpleResponse> execute(FormStatus status, FormType.Category category, String sort) {
+    public List<FormSimpleResponse> execute(FormStatus status, FormType type, String sort) {
         List<Form> formList = new java.util.ArrayList<>(formRepository.findByStatus(status).stream()
-                .filter(form -> Objects.isNull(category) || form.getType().categoryEquals(category))
+                .filter(form -> Objects.isNull(type) || form.getType().equals(type))
                 .toList());
 
         if (sort != null) {

--- a/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
@@ -206,7 +206,7 @@ public class FormController {
     public ListCommonResponse<FormSimpleResponse> getFormList(
             @AuthenticationPrincipal(authority = Authority.ADMIN) User user,
             @RequestParam(name = "status", required = false) FormStatus status,
-            @RequestParam(name = "type", required = false) FormType.Category type,
+            @RequestParam(name = "type", required = false) FormType type,
             @RequestParam(name = "sort", required = false) String sort
     ) {
         return ListCommonResponse.ok(

--- a/src/test/java/com/bamdoliro/maru/application/form/QueryAllFormUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/QueryAllFormUseCaseTest.java
@@ -68,10 +68,10 @@ class QueryAllFormUseCaseTest {
         given(formRepository.findByStatus(null)).willReturn(formList);
 
         // when
-        List<FormSimpleResponse> returnedFormList = queryAllFormUseCase.execute(null, FormType.Category.SPECIAL, null);
+        List<FormSimpleResponse> returnedFormList = queryAllFormUseCase.execute(null, FormType.MEISTER_TALENT, null);
 
         // then
-        assertEquals(2, returnedFormList.size());
+        assertEquals(1, returnedFormList.size());
 
         verify(formRepository, times(1)).findByStatus(null);
     }
@@ -91,7 +91,7 @@ class QueryAllFormUseCaseTest {
         given(formRepository.findByStatus(null)).willReturn(formList);
 
         // when
-        List<FormSimpleResponse> returnedFormList = queryAllFormUseCase.execute(null, FormType.Category.SOCIAL_INTEGRATION, null);
+        List<FormSimpleResponse> returnedFormList = queryAllFormUseCase.execute(null, FormType.MULTI_CHILDREN, null);
 
         // then
         assertEquals(1, returnedFormList.size());
@@ -190,7 +190,7 @@ class QueryAllFormUseCaseTest {
         given(formRepository.findByStatus(null)).willReturn(formList);
 
         // when
-        List<FormSimpleResponse> returnedFormList = queryAllFormUseCase.execute(null, FormType.Category.SOCIAL_INTEGRATION, "form-id");
+        List<FormSimpleResponse> returnedFormList = queryAllFormUseCase.execute(null, FormType.REGULAR, "form-id");
 
         // then
         assertEquals(1, returnedFormList.size());

--- a/src/test/java/com/bamdoliro/maru/presentation/form/FormControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/presentation/form/FormControllerTest.java
@@ -1686,11 +1686,11 @@ class FormControllerTest extends RestDocsTestSupport {
 
         given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
-        given(queryAllFormUseCase.execute(FormStatus.SUBMITTED, FormType.Category.REGULAR, null)).willReturn(responseList);
+        given(queryAllFormUseCase.execute(FormStatus.SUBMITTED, FormType.REGULAR, null)).willReturn(responseList);
 
         mockMvc.perform(get("/forms")
                         .param("status", FormStatus.SUBMITTED.name())
-                        .param("type", FormType.Category.REGULAR.name())
+                        .param("type", FormType.REGULAR.name())
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .accept(MediaType.APPLICATION_JSON)
                 )
@@ -1715,7 +1715,7 @@ class FormControllerTest extends RestDocsTestSupport {
                         )
                 ));
 
-        verify(queryAllFormUseCase, times(1)).execute(FormStatus.SUBMITTED, FormType.Category.REGULAR, null);
+        verify(queryAllFormUseCase, times(1)).execute(FormStatus.SUBMITTED, FormType.REGULAR, null);
     }
 
     @Test


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #229 

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 어드민 페이지에서 일반/마이스터인재전형을 제외한 원서들 필터링이 안되던 문제를 수정했습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- QueryAllFormUsecase의 매개변수와 filter 조건을 변경하였습니다.
- FormController의 매개변수를 변경하였습니다.
- 테스트 코드의 매개변수를 FormType.Category에서 FormType으로 같이 수정하였습니다


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

