### PR TITLE
[버그] 원서 반려 후 다시 제출 불가능

### DIFF
--- a/src/main/java/com/bamdoliro/maru/application/form/UpdateFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/UpdateFormUseCase.java
@@ -18,8 +18,8 @@ public class UpdateFormUseCase {
 
     @ValidateApplicationFormPeriod
     @Transactional
-    public void execute(User user, Long id, UpdateFormRequest request) {
-        Form form = formFacade.getForm(id);
+    public void execute(User user, UpdateFormRequest request) {
+        Form form = formFacade.getForm(user);
         form.isApplicant(user);
         validateFormStatus(form);
 

--- a/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
@@ -145,13 +145,12 @@ public class FormController {
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @PutMapping("/{form-id}")
+    @PutMapping()
     public void updateForm(
             @AuthenticationPrincipal(authority = Authority.USER) User user,
-            @PathVariable(name = "form-id") Long formId,
             @RequestBody @Valid UpdateFormRequest request
     ) {
-        updateFormUseCase.execute(user, formId, request);
+        updateFormUseCase.execute(user,  request);
     }
 
     @PostMapping( "/identification-picture")

--- a/src/test/java/com/bamdoliro/maru/application/form/UpdateFormUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/UpdateFormUseCaseTest.java
@@ -39,13 +39,13 @@ class UpdateFormUseCaseTest {
         form.reject();
         User user = form.getUser();
 
-        given(formFacade.getForm(form.getId())).willReturn(form);
+        given(formFacade.getForm(user)).willReturn(form);
 
         // when
-        updateFormUseCase.execute(user, form.getId(), FormFixture.createUpdateFormRequest(FormType.MEISTER_TALENT));
+        updateFormUseCase.execute(user, FormFixture.createUpdateFormRequest(FormType.MEISTER_TALENT));
 
         // then
-        verify(formFacade, times(1)).getForm(form.getId());
+        verify(formFacade, times(1)).getForm(user);
         assertEquals(FormType.MEISTER_TALENT, form.getType());
     }
 
@@ -55,13 +55,13 @@ class UpdateFormUseCaseTest {
         Long formId = 1L;
         User user = UserFixture.createUser();
 
-        willThrow(new FormNotFoundException()).given(formFacade).getForm(formId);
+        willThrow(new FormNotFoundException()).given(formFacade).getForm(user);
 
         // when and then
         assertThrows(FormNotFoundException.class, () ->
-                updateFormUseCase.execute(user, formId, FormFixture.createUpdateFormRequest(FormType.MEISTER_TALENT)));
+                updateFormUseCase.execute(user, FormFixture.createUpdateFormRequest(FormType.MEISTER_TALENT)));
 
-        verify(formFacade, times(1)).getForm(formId);
+        verify(formFacade, times(1)).getForm(user);
     }
 
     @Test
@@ -71,14 +71,14 @@ class UpdateFormUseCaseTest {
         form.reject();
         User otherUser = UserFixture.createUser();
 
-        given(formFacade.getForm(form.getId())).willReturn(form);
+        given(formFacade.getForm(otherUser)).willReturn(form);
 
         // when and then
         assertThrows(AuthorityMismatchException.class, () ->
-                updateFormUseCase.execute(otherUser, form.getId(), FormFixture.createUpdateFormRequest(FormType.MEISTER_TALENT))
+                updateFormUseCase.execute(otherUser, FormFixture.createUpdateFormRequest(FormType.MEISTER_TALENT))
         );
 
-        verify(formFacade, times(1)).getForm(form.getId());
+        verify(formFacade, times(1)).getForm(otherUser);
     }
 
     @Test
@@ -87,13 +87,13 @@ class UpdateFormUseCaseTest {
         Form form = FormFixture.createForm(FormType.REGULAR);
         User user = form.getUser();
 
-        given(formFacade.getForm(form.getId())).willReturn(form);
+        given(formFacade.getForm(user)).willReturn(form);
 
         // when and then
         assertThrows(CannotUpdateNotRejectedFormException.class, () ->
-                updateFormUseCase.execute(user, form.getId(), FormFixture.createUpdateFormRequest(FormType.MEISTER_TALENT))
+                updateFormUseCase.execute(user, FormFixture.createUpdateFormRequest(FormType.MEISTER_TALENT))
         );
 
-        verify(formFacade, times(1)).getForm(form.getId());
+        verify(formFacade, times(1)).getForm(user);
     }
 }

--- a/src/test/java/com/bamdoliro/maru/presentation/form/FormControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/presentation/form/FormControllerTest.java
@@ -695,10 +695,10 @@ class FormControllerTest extends RestDocsTestSupport {
 
         given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
-        willDoNothing().given(updateFormUseCase).execute(user, formId, request);
+        willDoNothing().given(updateFormUseCase).execute(user, request);
 
 
-        mockMvc.perform(put("/forms/{form-id}", formId)
+        mockMvc.perform(put("/forms")
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -711,10 +711,6 @@ class FormControllerTest extends RestDocsTestSupport {
                         requestHeaders(
                                 headerWithName(HttpHeaders.AUTHORIZATION)
                                         .description("Bearer token")
-                        ),
-                        pathParameters(
-                                parameterWithName("form-id")
-                                        .description("수정할 원서 id")
                         ),
                         requestFields(
                                 fieldWithPath("type")
@@ -853,7 +849,7 @@ class FormControllerTest extends RestDocsTestSupport {
                         )
                 ));
 
-        verify(updateFormUseCase, times(1)).execute(any(User.class), anyLong(), any(UpdateFormRequest.class));
+        verify(updateFormUseCase, times(1)).execute(any(User.class),  any(UpdateFormRequest.class));
     }
 
     @Test
@@ -864,9 +860,9 @@ class FormControllerTest extends RestDocsTestSupport {
 
         given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
-        doThrow(new OutOfApplicationFormPeriodException()).when(updateFormUseCase).execute(any(User.class), anyLong(), any(UpdateFormRequest.class));
+        doThrow(new OutOfApplicationFormPeriodException()).when(updateFormUseCase).execute(any(User.class), any(UpdateFormRequest.class));
 
-        mockMvc.perform(put("/forms/{form-id}", formId)
+        mockMvc.perform(put("/forms")
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -877,7 +873,7 @@ class FormControllerTest extends RestDocsTestSupport {
 
                 .andDo(restDocs.document());
 
-        verify(updateFormUseCase, times(1)).execute(any(User.class), anyLong(), any(UpdateFormRequest.class));
+        verify(updateFormUseCase, times(1)).execute(any(User.class), any(UpdateFormRequest.class));
     }
 
     @Test
@@ -887,10 +883,10 @@ class FormControllerTest extends RestDocsTestSupport {
 
         given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
-        doThrow(new FormNotFoundException()).when(updateFormUseCase).execute(any(User.class), anyLong(), any(UpdateFormRequest.class));
+        doThrow(new FormNotFoundException()).when(updateFormUseCase).execute(any(User.class), any(UpdateFormRequest.class));
 
 
-        mockMvc.perform(put("/forms/{form-id}", formId)
+        mockMvc.perform(put("/forms")
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -901,7 +897,7 @@ class FormControllerTest extends RestDocsTestSupport {
 
                 .andDo(restDocs.document());
 
-        verify(updateFormUseCase, times(1)).execute(any(User.class), anyLong(), any(UpdateFormRequest.class));
+        verify(updateFormUseCase, times(1)).execute(any(User.class), any(UpdateFormRequest.class));
     }
 
     @Test
@@ -911,10 +907,10 @@ class FormControllerTest extends RestDocsTestSupport {
 
         given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
-        doThrow(new AuthorityMismatchException()).when(updateFormUseCase).execute(any(User.class), anyLong(), any(UpdateFormRequest.class));
+        doThrow(new AuthorityMismatchException()).when(updateFormUseCase).execute(any(User.class), any(UpdateFormRequest.class));
 
 
-        mockMvc.perform(put("/forms/{form-id}", formId)
+        mockMvc.perform(put("/forms")
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -925,7 +921,7 @@ class FormControllerTest extends RestDocsTestSupport {
 
                 .andDo(restDocs.document());
 
-        verify(updateFormUseCase, times(1)).execute(any(User.class), anyLong(), any(UpdateFormRequest.class));
+        verify(updateFormUseCase, times(1)).execute(any(User.class), any(UpdateFormRequest.class));
     }
 
     @Test
@@ -935,10 +931,10 @@ class FormControllerTest extends RestDocsTestSupport {
 
         given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
-        doThrow(new CannotUpdateNotRejectedFormException()).when(updateFormUseCase).execute(any(User.class), anyLong(), any(UpdateFormRequest.class));
+        doThrow(new CannotUpdateNotRejectedFormException()).when(updateFormUseCase).execute(any(User.class), any(UpdateFormRequest.class));
 
 
-        mockMvc.perform(put("/forms/{form-id}", formId)
+        mockMvc.perform(put("/forms", formId)
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -949,7 +945,7 @@ class FormControllerTest extends RestDocsTestSupport {
 
                 .andDo(restDocs.document());
 
-        verify(updateFormUseCase, times(1)).execute(any(User.class), anyLong(), any(UpdateFormRequest.class));
+        verify(updateFormUseCase, times(1)).execute(any(User.class), any(UpdateFormRequest.class));
     }
 
     @Test


### PR DESCRIPTION
## 🎫 관련 이슈

close #240 

<br>

## 📄 개요

> 원서 반려 후 수정하는 API 수정

<br>

## 🔨 작업 내용

- UpdateFormUseCase를 호출할 때 매개변수로 id를 받지 않고 유저로 로드맵을 호출 후 수정하도록 변경


<br>

## 🏁 확인 사항

- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말

