### PR TITLE
[버그] 1차 전형 합/불 대상 원서 상태 수정

### DIFF
--- a/src/main/java/com/bamdoliro/maru/application/form/SelectFirstPassUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/SelectFirstPassUseCase.java
@@ -29,7 +29,7 @@ public class SelectFirstPassUseCase {
         int nationalVeteransEducationCount = FixedNumber.NATIONAL_VETERANS_EDUCATION;
         int specialAdmissionCount = FixedNumber.SPECIAL_ADMISSION;
 
-        List<Form> specialFormList = formRepository.findReceivedSpecialForm();
+        List<Form> specialFormList = formRepository.findApprovedSpecialForm();
         List<Form> meisterTalentFormList = classifyFormsByType(specialFormList, FormType::isMeister);
         List<Form> socialIntegrationFormList = classifyFormsByType(specialFormList, FormType::isSocial);
         List<Form> equalOpportunityFormList = classifyFormsByType(specialFormList, FormType::isEqualOpportunity);
@@ -60,12 +60,12 @@ public class SelectFirstPassUseCase {
         processForms(meisterTalentFormList, meisterTalentCount, this::changeToRegularAndCalculateGradeAgain);
 
         formRepository.flush();
-        List<Form> regularFormList = formRepository.findReceivedRegularForm();
+        List<Form> regularFormList = formRepository.findApprovedRegularForm();
 
         processForms(regularFormList, regularCount, Form::firstFail);
 
         formRepository.flush();
-        List<Form> supernumeraryFormList = formRepository.findReceivedSupernumeraryForm();
+        List<Form> supernumeraryFormList = formRepository.findApprovedSupernumeraryForm();
         List<Form> nationalVeteransFormList = classifyFormsByType(supernumeraryFormList, FormType::isNationalVeteransEducation);
         List<Form> specialAdmissionFormList = classifyFormsByType(supernumeraryFormList, FormType::isSpecialAdmission);
 

--- a/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepositoryCustom.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepositoryCustom.java
@@ -16,9 +16,9 @@ public interface FormRepositoryCustom {
     List<Form> findByType(FormType type);
     List<Form> findByCategory(FormType.Category category);
     List<Form> findByOriginalCategory(FormType.Category category);
-    List<Form> findReceivedSpecialForm();
-    List<Form> findReceivedRegularForm();
-    List<Form> findReceivedSupernumeraryForm();
+    List<Form> findApprovedSpecialForm();
+    List<Form> findApprovedRegularForm();
+    List<Form> findApprovedSupernumeraryForm();
     List<Form> findFirstPassedSpecialForm();
     List<Form> findFirstPassedRegularForm();
     List<Form> findFirstPassedSupernumeraryForm();

--- a/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepositoryImpl.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepositoryImpl.java
@@ -80,11 +80,11 @@ public class FormRepositoryImpl implements FormRepositoryCustom {
     }
 
     @Override
-    public List<Form> findReceivedSpecialForm() {
+    public List<Form> findApprovedSpecialForm() {
         return queryFactory
                 .selectFrom(form)
                 .where(
-                        form.status.eq(FormStatus.RECEIVED)
+                        form.status.eq(FormStatus.APPROVED)
                                 .and(
                                         form.type.eq(FormType.REGULAR).not()
                                                 .and(form.type.eq(FormType.NATIONAL_VETERANS_EDUCATION).not())
@@ -96,11 +96,11 @@ public class FormRepositoryImpl implements FormRepositoryCustom {
     }
 
     @Override
-    public List<Form> findReceivedRegularForm() {
+    public List<Form> findApprovedRegularForm() {
         return queryFactory
                 .selectFrom(form)
                 .where(
-                        form.status.eq(FormStatus.RECEIVED)
+                        form.status.eq(FormStatus.APPROVED)
                                 .and(
                                         form.type.eq(FormType.REGULAR)
                                                 .or(form.changedToRegular.isTrue())
@@ -111,11 +111,11 @@ public class FormRepositoryImpl implements FormRepositoryCustom {
     }
 
     @Override
-    public List<Form> findReceivedSupernumeraryForm() {
+    public List<Form> findApprovedSupernumeraryForm() {
         return queryFactory
                 .selectFrom(form)
                 .where(
-                        form.status.eq(FormStatus.RECEIVED)
+                        form.status.eq(FormStatus.APPROVED)
                                 .and(
                                         form.type.eq(FormType.SPECIAL_ADMISSION)
                                                 .or(form.type.eq(FormType.NATIONAL_VETERANS_EDUCATION))

--- a/src/test/java/com/bamdoliro/maru/application/form/SelectFirstPassUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/SelectFirstPassUseCaseTest.java
@@ -54,7 +54,7 @@ class SelectFirstPassUseCaseTest {
         formList.addAll(FormFixture.generateOtherRegionFormList(userList.subList(userList.size() / 2, userList.size())));
         formList.forEach(form -> {
             assignExaminationNumberService.execute(form);
-            form.receive();
+            form.approve();
             calculateFormScoreService.execute(form);
             formRepository.save(form);
         });

--- a/src/test/java/com/bamdoliro/maru/application/form/SelectSecondPassUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/SelectSecondPassUseCaseTest.java
@@ -61,7 +61,7 @@ public class SelectSecondPassUseCaseTest {
         formList.addAll(FormFixture.generateOtherRegionFormList(userList.subList(userList.size() / 2, userList.size())));
         formList.forEach(form -> {
             assignExaminationNumberService.execute(form);
-            form.receive();
+            form.approve();
             calculateFormScoreService.execute(form);
             formRepository.save(form);
         });

--- a/src/test/java/com/bamdoliro/maru/application/form/UpdateSecondRoundScoreUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/UpdateSecondRoundScoreUseCaseTest.java
@@ -60,7 +60,7 @@ class UpdateSecondRoundScoreUseCaseTest {
         List<Form> formList = FormFixture.generateBusanFormList(userList);
         formList.forEach(form -> {
             assignExaminationNumberService.execute(form);
-            form.receive();
+            form.approve();
             calculateFormScoreService.execute(form);
             if (form.getExaminationNumber() == 1001 ||
                     form.getExaminationNumber() == 1002 ||


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #249

<br>

## 📄 개요

> 1차 전형 합격자 계산의 대상 원서 상태를 수정했습니다

<br>

## 🔨 작업 내용

- FormRepository에서 접수된 원서를 반환하던 메서드를 승인된 원서를 반환하도록 변경했습니다.
- SelectFirstPassUseCase에서 승인된 원서를 받아와 합격 여부를 판단하도록 변경했습니다.


<br>

## 🏁 확인 사항

- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말

