### PR TITLE
[버그] 2차 점수 입력 엑셀 오류

### DIFF
--- a/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
@@ -268,7 +268,7 @@ public class FormController {
                 .body(downloadSecondRoundScoreFormatUseCase.execute());
     }
 
-    @PatchMapping("/second-round/score")
+    @PostMapping("/second-round/score")
     public ResponseEntity<Resource> updateSecondRoundScore(
             @AuthenticationPrincipal(authority = Authority.ADMIN) User user,
             @RequestPart(value = "xlsx") MultipartFile file

--- a/src/test/java/com/bamdoliro/maru/presentation/form/FormControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/presentation/form/FormControllerTest.java
@@ -2031,7 +2031,7 @@ class FormControllerTest extends RestDocsTestSupport {
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
         given(downloadSecondRoundScoreFormatUseCase.execute()).willReturn(null);
 
-        mockMvc.perform(multipartPatch("/forms/second-round/score")
+        mockMvc.perform(multipart("/forms/second-round/score")
                         .file(file)
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .contentType(MediaType.MULTIPART_FORM_DATA))
@@ -2066,7 +2066,7 @@ class FormControllerTest extends RestDocsTestSupport {
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
         doThrow(new InvalidFileException("")).when(updateSecondRoundScoreUseCase).execute(any(MultipartFile.class));
 
-        mockMvc.perform(multipartPatch("/forms/second-round/score")
+        mockMvc.perform(multipart("/forms/second-round/score")
                         .file(file)
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .contentType(MediaType.MULTIPART_FORM_DATA))
@@ -2092,7 +2092,7 @@ class FormControllerTest extends RestDocsTestSupport {
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
         given(updateSecondRoundScoreUseCase.execute(file)).willReturn(new ByteArrayResource(file.getBytes()));
 
-        mockMvc.perform(multipartPatch("/forms/second-round/score")
+        mockMvc.perform(multipart("/forms/second-round/score")
                         .file(file)
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .contentType(MediaType.MULTIPART_FORM_DATA))


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #262

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 2차 점수 엑셀 입력의 http메서드를 변경하였습니다

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- 컨트롤러의 Http 메서드를 Patch -> Post로 변경하였습니다


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

