### PR TITLE
[버그] 모의계산과 실제 원서의 점수가 다른 문제 

### DIFF
--- a/src/main/java/com/bamdoliro/maru/domain/form/domain/value/Subject.java
+++ b/src/main/java/com/bamdoliro/maru/domain/form/domain/value/Subject.java
@@ -77,6 +77,12 @@ public class Subject {
     }
 
     public Integer getCount() {
+        if(achievementLevel == AchievementLevel.F) {
+            if(!(subjectName.equals("수학") || subjectName.equals("국어") || subjectName.equals("영어"))){
+                return 0;
+            }
+        }
+
         if (subjectName.equals("수학")) {
             return 2;
         }


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #288

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 미이수일 경우 교과목 카운트에 0이 들어가도록 하였습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- getCount 메서드에서 미이수일 경우 교과목의 개수가 0이 반환되도록 하였습니다.


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [ ] 테스트를 완료했나요?
- [ ] API 문서를 작성했나요?
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

