### PR TITLE
[버그] 반려 후 원서 pdf에 같은 값이 들어가는 문제

### DIFF
--- a/src/main/java/com/bamdoliro/maru/application/form/UpdateFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/UpdateFormUseCase.java
@@ -2,8 +2,10 @@ package com.bamdoliro.maru.application.form;
 
 import com.bamdoliro.maru.domain.form.domain.Form;
 import com.bamdoliro.maru.domain.form.exception.CannotUpdateNotRejectedFormException;
+import com.bamdoliro.maru.domain.form.service.CalculateFormScoreService;
 import com.bamdoliro.maru.domain.form.service.FormFacade;
 import com.bamdoliro.maru.domain.user.domain.User;
+import com.bamdoliro.maru.infrastructure.persistence.form.FormRepository;
 import com.bamdoliro.maru.presentation.form.dto.request.UpdateFormRequest;
 import com.bamdoliro.maru.shared.annotation.UseCase;
 import com.bamdoliro.maru.shared.annotation.ValidateApplicationFormPeriod;
@@ -15,6 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class UpdateFormUseCase {
 
     private final FormFacade formFacade;
+    private final CalculateFormScoreService calculateFormScoreService;
+    private final FormRepository formRepository;
 
     @ValidateApplicationFormPeriod
     @Transactional
@@ -31,6 +35,10 @@ public class UpdateFormUseCase {
                 request.getDocument().toValue(),
                 request.getType()
         );
+
+        calculateFormScoreService.execute(form);
+        formRepository.save(form);
+
     }
 
     private void validateFormStatus(Form form) {

--- a/src/test/java/com/bamdoliro/maru/application/form/UpdateFormUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/UpdateFormUseCaseTest.java
@@ -5,8 +5,10 @@ import com.bamdoliro.maru.domain.form.domain.Form;
 import com.bamdoliro.maru.domain.form.domain.type.FormType;
 import com.bamdoliro.maru.domain.form.exception.CannotUpdateNotRejectedFormException;
 import com.bamdoliro.maru.domain.form.exception.FormNotFoundException;
+import com.bamdoliro.maru.domain.form.service.CalculateFormScoreService;
 import com.bamdoliro.maru.domain.form.service.FormFacade;
 import com.bamdoliro.maru.domain.user.domain.User;
+import com.bamdoliro.maru.infrastructure.persistence.form.FormRepository;
 import com.bamdoliro.maru.shared.fixture.FormFixture;
 import com.bamdoliro.maru.shared.fixture.UserFixture;
 import org.junit.jupiter.api.Test;
@@ -31,6 +33,11 @@ class UpdateFormUseCaseTest {
     @Mock
     private FormFacade formFacade;
 
+    @Mock
+    private CalculateFormScoreService calculateFormScoreService;
+
+    @Mock
+    private FormRepository formRepository;
 
     @Test
     void 원서를_수정한다() {


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #290 

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 반려된 원서의 성적을 바꾸어 입력해도 점수가 바뀌지 않는 문제를 해결하였습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- UpdateFormUseCase에  Calculater 와 FormRepository를 추가하여 각각 점수 계산후 저장하도록 하였습니다.


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [ ] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

