### PR TITLE
[개선] 타임리프 년도 포맷팅 'yyyy'로 통일

### DIFF
--- a/src/main/resources/templates/admission-ticket.html
+++ b/src/main/resources/templates/admission-ticket.html
@@ -153,7 +153,7 @@
             </tr>
             <tr>
                 <th scope="row" class="ba">생년월일</th>
-                <td class="ba left" th:text="${#temporals.format(form.applicant.birthday, 'YYYY년 MM월 dd일')}"></td>
+                <td class="ba left" th:text="${#temporals.format(form.applicant.birthday, 'yyyy년 MM월 dd일')}"></td>
             </tr>
             <tr>
                 <th scope="row" class="ba"><span style="margin-right: 40px">성</span>명</th>

--- a/src/main/resources/templates/confirmation.html
+++ b/src/main/resources/templates/confirmation.html
@@ -110,7 +110,7 @@
         <p class="indent">위 학생의 특례 신입학 학적 서류는 외국 학교의 재적학교장이 발급한 학적 서류임을 확인하며,
             만약 위·변조 서류로 확인될 경우에는 입학 취소 등 모든 행정처분에 따를 것을 확인합니다.</p>
         <div style="height: 32px;"></div>
-        <p class="middle center" th:text="${#dates.format(#dates.createNow(),'YYYY년 MM월 dd일')}">년&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;월&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;일</p>
+        <p class="middle center" th:text="${#dates.format(#dates.createNow(),'yyyy년 MM월 dd일')}">년&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;월&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;일</p>
         <div style="height: 42px;"></div>
         <div class="indent"><span style="margin-right: 80px">확생과의 관계(보호자) :</span>
             <span style="margin-right: 80px">성명 :</span>

--- a/src/main/resources/templates/form.html
+++ b/src/main/resources/templates/form.html
@@ -410,7 +410,7 @@
                 본인은 2025학년도 귀고 입학전형에 응시하고자 소정의 서류를 갖추어 지원하며 교칙을 준수하고, 다른 마이스터고등학교에 이중 지원을 하지 않을 것을 서약합니다.
             </p>
             <div class="space"></div>
-            <p class="middle" th:text="${#dates.format(#dates.createNow(),'YYYY년 MM월 dd일')}"></p>
+            <p class="middle" th:text="${#dates.format(#dates.createNow(),'yyyy년 MM월 dd일')}"></p>
             <div class="space"></div>
             <div class="right">
                 <div class="left middle inline">
@@ -433,7 +433,7 @@
         <td class="ba text-box" colspan="21">
             <p class="left middle">위의 기재 사항은 사실과 상위없음을 확인하고, 귀교의 신입생 입학전형 대상자로 추천합니다.</p>
             <div class="space"></div>
-            <p class="middle" th:text="${#dates.format(#dates.createNow(),'YYYY년 MM월 dd일')}"></p>
+            <p class="middle" th:text="${#dates.format(#dates.createNow(),'yyyy년 MM월 dd일')}"></p>
             <div class="space"></div>
             <p class="school right space-right">
                 <span th:text="${form.education.school.name}"></span>장&nbsp;&nbsp;

--- a/src/main/resources/templates/no-smoking.html
+++ b/src/main/resources/templates/no-smoking.html
@@ -132,7 +132,7 @@
                 </tr>
             </table>
             <div style="height: 48px;"></div>
-            <p class="middle center" th:text="${#dates.format(#dates.createNow(),'YYYY년 MM월 dd일')}"></p>
+            <p class="middle center" th:text="${#dates.format(#dates.createNow(),'yyyy년 MM월 dd일')}"></p>
             <div style="height: 54px;"></div>
             <p class="right">
                 지원자&nbsp;&nbsp;

--- a/src/main/resources/templates/privacy-policy-agreement.html
+++ b/src/main/resources/templates/privacy-policy-agreement.html
@@ -268,7 +268,7 @@
         </tr>
     </table>
     <div class = "middle center" style = "font-size : 14px;">개인정보 보호법 등 관련 법규에 의거하여 입학지원서 개인정보 수집·이용·제공에 동의합니다.</div>
-    <div class="middle center" th:text="${#dates.format(#dates.createNow(),'YYYY년 MM월 dd일')}">202&nbsp;년 &nbsp;&nbsp;월
+    <div class="middle center" th:text="${#dates.format(#dates.createNow(),'yyyy년 MM월 dd일')}">202&nbsp;년 &nbsp;&nbsp;월
         &nbsp;&nbsp;일
     </div>
     <p class="middle right">

--- a/src/main/resources/templates/qualification-form.html
+++ b/src/main/resources/templates/qualification-form.html
@@ -410,7 +410,7 @@
                 본인은 2025학년도 귀고 입학전형에 응시하고자 소정의 서류를 갖추어 지원하며 교칙을 준수하고, 다른 마이스터고등학교에 이중 지원을 하지 않을 것을 서약합니다.
             </p>
             <div class="space"></div>
-            <p class="middle" th:text="${#dates.format(#dates.createNow(),'YYYY년 MM월 dd일')}"></p>
+            <p class="middle" th:text="${#dates.format(#dates.createNow(),'yyyy년 MM월 dd일')}"></p>
             <div class="space"></div>
             <div class="right">
                 <div class="left middle inline">

--- a/src/main/resources/templates/recommendation.html
+++ b/src/main/resources/templates/recommendation.html
@@ -144,7 +144,7 @@
             <div style="height: 72px;"></div>
             <p class="left indent">위 학생을 <span th:text="${year}"></span>학년도 부산소프트웨어마이스터고등학교 특별전형 대상자로 추천합니다.</p>
             <div style="height: 81px;"></div>
-            <p class="middle" th:text="${#dates.format(#dates.createNow(),'YYYY년 MM월 dd일')}"></p>
+            <p class="middle" th:text="${#dates.format(#dates.createNow(),'yyyy년 MM월 dd일')}"></p>
             <div style="height: 96px;"></div>
             <p class="middle">
                 작성자 담임:&nbsp;&nbsp;

--- a/src/main/resources/templates/registration.html
+++ b/src/main/resources/templates/registration.html
@@ -160,7 +160,7 @@
     <td class="text-box middle left padding" colspan="4">
         <p class="middle left">상기 본인은 2025학년도 부산소프트웨어마이스터고등학교 최종 합격자로서 본교 제1학년에 입학하고자 다음과 같이 입학등록원을 제출합니다.</p>
         <div style="height: 45px;"></div>
-        <div class="middle center" th:text="${#dates.format(#dates.createNow(),'YYYY년 MM월 dd일')}">2024년 12월 21일</div>
+        <div class="middle center" th:text="${#dates.format(#dates.createNow(),'yyyy년 MM월 dd일')}">2024년 12월 21일</div>
         <div style="height: 40px;"></div>
         <p class="middle right">
             <span class="sign">학&nbsp;&nbsp;&nbsp;&nbsp;생 : </span>

--- a/src/main/resources/templates/special-admission.html
+++ b/src/main/resources/templates/special-admission.html
@@ -283,7 +283,7 @@
             <div style="height: 24px;"></div>
             <p class="indent bold">본인은 2025학년도 부산광역시 고등학교 입학전형 특례 대상자로 심사받고자 보호자 연서로 원서를 제출합니다.</p>
             <div style="height: 15px;"></div>
-            <p class="middle center" th:text="${#dates.format(#dates.createNow(),'YYYY. MM. dd.')}">2024. 9. 5.</p>
+            <p class="middle center" th:text="${#dates.format(#dates.createNow(),'yyyy. MM. dd.')}">2024. 9. 5.</p>
             <div style="height: 15px;"></div>
             <p class="middle center">
                 <span class="sign">학&nbsp;&nbsp;&nbsp;생 성명</span>

--- a/src/main/resources/templates/written-oath.html
+++ b/src/main/resources/templates/written-oath.html
@@ -131,7 +131,7 @@
             <div style="height: 20px;"></div>
             <p class="indent">지원자 본인과 보호자는 위 모든 사항을 숙지하였으며 이를 위반했을 경우 학교가 취하는 조치에 대하여 이의를 제기하지 않고 성실히 따를 것을 서약합니다.</p>
             <div style="height: 48px;"></div>
-            <p class="middle center" th:text="${#dates.format(#dates.createNow(),'YYYY년 MM월 dd일')}">2024년 9월 5일</p>
+            <p class="middle center" th:text="${#dates.format(#dates.createNow(),'yyyy년 MM월 dd일')}">2024년 9월 5일</p>
             <div style="height: 54px;"></div>
             <p class="middle right">
                 <span class="sign">지원자 성명 : </span>


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #300

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> YYYY 형식을 yyyy로 변경하엿습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- 타임리프 템플릿의 연도 포맷팅 형식을 YYYY 에서 yyyy로 변경하였습니다.


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [ ] 테스트를 완료했나요?
- [ ] API 문서를 작성했나요?
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

