### PR TITLE
[개선] DTO에서 Repository 의존 문제

### DIFF
--- a/src/main/java/com/bamdoliro/maru/application/fair/AttendAdmissionFairUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/fair/AttendAdmissionFairUseCase.java
@@ -44,7 +44,7 @@ public class AttendAdmissionFairUseCase {
     }
 
     private void validateFairCapacity(Fair fair, Integer headcount) {
-        if (fair.getHeadcount(attendeeRepository) + headcount > fair.getCapacity()) {
+        if (attendeeRepository.countByFair(fair) + headcount > fair.getCapacity()) {
             throw new HeadcountExceededException();
         }
     }

--- a/src/main/java/com/bamdoliro/maru/application/fair/QueryFairDetailUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/fair/QueryFairDetailUseCase.java
@@ -15,6 +15,7 @@ public class QueryFairDetailUseCase {
 
     public FairDetailResponse execute(Long fairId) {
         Fair fair = fairFacade.getFairDetail(fairId);
-        return new FairDetailResponse(fair, attendeeRepository);
+        Integer headCount = attendeeRepository.countByFair(fair);
+        return new FairDetailResponse(fair, headCount);
     }
 }

--- a/src/main/java/com/bamdoliro/maru/application/fair/QueryFairListUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/fair/QueryFairListUseCase.java
@@ -19,7 +19,10 @@ public class QueryFairListUseCase {
     public List<FairResponse> execute(FairType type) {
         return fairRepository.findByType(type)
                 .stream()
-                .map((fair) -> new FairResponse(fair, attendeeRepository))
+                .map(fair -> {
+                    Integer headCount = attendeeRepository.countByFair(fair);
+                    return new FairResponse(fair, headCount);
+                })
                 .toList();
     }
 }

--- a/src/main/java/com/bamdoliro/maru/domain/fair/domain/Fair.java
+++ b/src/main/java/com/bamdoliro/maru/domain/fair/domain/Fair.java
@@ -63,7 +63,7 @@ public class Fair extends BaseTimeEntity {
         return attendeeRepository.countByFair(this);
     }
 
-    public FairStatus getStatus(AttendeeRepository attendeeRepository) {
+    public FairStatus getStatus(Integer headcount) {
         LocalDateTime now = LocalDateTime.now();
         if (now.isAfter(start)) {
             return FairStatus.CLOSED;
@@ -71,7 +71,7 @@ public class Fair extends BaseTimeEntity {
             return FairStatus.APPLICATION_NOT_STARTED;
         } else if (now.toLocalDate().isAfter(applicationEndDate)) {
             return FairStatus.APPLICATION_ENDED;
-        } else if (getHeadcount(attendeeRepository) >= capacity) {
+        } else if (headcount >= capacity) {
             return FairStatus.APPLICATION_EARLY_CLOSED;
         }
 

--- a/src/main/java/com/bamdoliro/maru/domain/fair/domain/Fair.java
+++ b/src/main/java/com/bamdoliro/maru/domain/fair/domain/Fair.java
@@ -2,7 +2,6 @@ package com.bamdoliro.maru.domain.fair.domain;
 
 import com.bamdoliro.maru.domain.fair.domain.type.FairStatus;
 import com.bamdoliro.maru.domain.fair.domain.type.FairType;
-import com.bamdoliro.maru.infrastructure.persistence.fair.AttendeeRepository;
 import com.bamdoliro.maru.shared.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -57,10 +56,6 @@ public class Fair extends BaseTimeEntity {
         this.type = type;
         this.applicationStartDate = applicationStartDate;
         this.applicationEndDate = applicationEndDate;
-    }
-
-    public Integer getHeadcount(AttendeeRepository attendeeRepository) {
-        return attendeeRepository.countByFair(this);
     }
 
     public FairStatus getStatus(Integer headcount) {

--- a/src/main/java/com/bamdoliro/maru/presentation/fair/dto/response/FairDetailResponse.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/fair/dto/response/FairDetailResponse.java
@@ -2,7 +2,6 @@ package com.bamdoliro.maru.presentation.fair.dto.response;
 
 import com.bamdoliro.maru.domain.fair.domain.Fair;
 import com.bamdoliro.maru.domain.fair.domain.type.FairStatus;
-import com.bamdoliro.maru.infrastructure.persistence.fair.AttendeeRepository;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -22,12 +21,12 @@ public class FairDetailResponse {
     private FairStatus status;
     private List<AttendeeResponse> attendeeList;
 
-    public FairDetailResponse(Fair fair, AttendeeRepository attendeeRepository) {
+    public FairDetailResponse(Fair fair, Integer headCount) {
         this.start = fair.getStart();
         this.place = fair.getPlace();
         this.applicationStartDate = fair.getApplicationStartDate();
         this.applicationEndDate = fair.getApplicationEndDate();
-        this.status = fair.getStatus(attendeeRepository);
+        this.status = fair.getStatus(headCount);
         this.attendeeList = fair.getAttendeeList().stream()
                 .map(AttendeeResponse::new)
                 .collect(Collectors.toList());

--- a/src/main/java/com/bamdoliro/maru/presentation/fair/dto/response/FairResponse.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/fair/dto/response/FairResponse.java
@@ -2,7 +2,6 @@ package com.bamdoliro.maru.presentation.fair.dto.response;
 
 import com.bamdoliro.maru.domain.fair.domain.Fair;
 import com.bamdoliro.maru.domain.fair.domain.type.FairStatus;
-import com.bamdoliro.maru.infrastructure.persistence.fair.AttendeeRepository;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -20,12 +19,12 @@ public class FairResponse {
     private LocalDate applicationEndDate;
     private FairStatus status;
 
-    public FairResponse(Fair fair, AttendeeRepository attendeeRepository) {
+    public FairResponse(Fair fair, Integer headCount) {
         this.id = fair.getId();
         this.start = fair.getStart();
         this.place = fair.getPlace();
         this.applicationStartDate = fair.getApplicationStartDate();
         this.applicationEndDate = fair.getApplicationEndDate();
-        this.status = fair.getStatus(attendeeRepository);
+        this.status = fair.getStatus(headCount);
     }
 }


### PR DESCRIPTION
Integer 타입의 headCount를 매개변수로 받게 하여 의존관계를 제거하였습니다.

## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #327 

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 의존관계를 수정하였습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- FairResponse, FairDetatilResponse에서 AttendeRepository를 매개변수에서 삭제하였습니다.
- Fair의 getHeadCount메서드의 파라미터를 수정하였습니다.


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [ ] 테스트를 완료했나요?
- [ ] API 문서를 작성했나요?
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

