### PR TITLE
[개선] 토큰 타입 검증을 String에서 enum으로 변경

### DIFF
--- a/src/main/java/com/bamdoliro/maru/application/auth/RefreshTokenUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/auth/RefreshTokenUseCase.java
@@ -31,7 +31,7 @@ public class RefreshTokenUseCase {
     }
 
     private void validate(String token) {
-        if (!Objects.equals(tokenService.getType(token), TokenType.REFRESH_TOKEN.name())) {
+        if (tokenService.getType(token) != TokenType.REFRESH_TOKEN) {
             throw new InvalidTokenException();
         }
     }

--- a/src/main/java/com/bamdoliro/maru/domain/auth/service/TokenService.java
+++ b/src/main/java/com/bamdoliro/maru/domain/auth/service/TokenService.java
@@ -70,8 +70,10 @@ public class TokenService {
         return extractAllClaims(token).get("uuid", String.class);
     }
 
-    public String getType(String token) {
-        return extractAllClaims(token).get("type", String.class);
+    public TokenType getType(String token) {
+        return TokenType.valueOf(
+                extractAllClaims(token).get("type", String.class)
+        );
     }
 
     private Claims extractAllClaims(String token) {

--- a/src/test/java/com/bamdoliro/maru/application/auth/RefreshTokenUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/auth/RefreshTokenUseCaseTest.java
@@ -42,7 +42,7 @@ class RefreshTokenUseCaseTest {
         // given
         Token refreshToken = AuthFixture.createRefreshToken();
         String accessToken = AuthFixture.createAccessTokenString();
-        given(tokenService.getType(refreshToken.getToken())).willReturn(TokenType.REFRESH_TOKEN.name());
+        given(tokenService.getType(refreshToken.getToken())).willReturn(TokenType.REFRESH_TOKEN);
         given(tokenService.getUuid(refreshToken.getToken())).willReturn(refreshToken.getUuid());
         given(tokenRepository.findById(refreshToken.getUuid())).willReturn(Optional.of(refreshToken));
         given(tokenService.generateAccessToken(refreshToken.getUuid())).willReturn(accessToken);
@@ -75,7 +75,7 @@ class RefreshTokenUseCaseTest {
         // given
         String loggedOutRefreshToken = "로그아웃.리프레시.토큰";
         Token refreshToken = AuthFixture.createRefreshToken();
-        given(tokenService.getType(loggedOutRefreshToken)).willReturn(TokenType.REFRESH_TOKEN.name());
+        given(tokenService.getType(loggedOutRefreshToken)).willReturn(TokenType.REFRESH_TOKEN);
         given(tokenService.getUuid(loggedOutRefreshToken)).willReturn(refreshToken.getUuid());
         given(tokenRepository.findById(refreshToken.getUuid())).willReturn(Optional.of(refreshToken));
 
@@ -87,7 +87,7 @@ class RefreshTokenUseCaseTest {
     void 액세스_토큰으로_재발급을_시도하면_에러가_발생한다() {
         // given
         String accessToken = "이것은.액세스.토큰";
-        given(tokenService.getType(accessToken)).willReturn(TokenType.ACCESS_TOKEN.name());
+        given(tokenService.getType(accessToken)).willReturn(TokenType.ACCESS_TOKEN);
 
         // when and then
         assertThrows(InvalidTokenException.class, () -> refreshTokenUseCase.execute(accessToken));


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #330 

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 리프레쉬 토큰 타입 검증을 String이 아닌 enum으로 검증하도록 하였습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- getType의 반환형을 TokenType으로 변경하였습니다.
- validate 메서드의 조건문을 equals 메서드가 아닌 != 연산자로 변경하여 의미를 명확하게 하였습니다.


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

