### PR TITLE
[개선] AuthenticationArgumentResolver의 과도한 책임문제

### DIFF
--- a/src/main/java/com/bamdoliro/maru/domain/auth/service/TokenService.java
+++ b/src/main/java/com/bamdoliro/maru/domain/auth/service/TokenService.java
@@ -4,8 +4,6 @@ import com.bamdoliro.maru.domain.auth.domain.Token;
 import com.bamdoliro.maru.domain.auth.domain.type.TokenType;
 import com.bamdoliro.maru.domain.auth.exception.ExpiredTokenException;
 import com.bamdoliro.maru.domain.auth.exception.InvalidTokenException;
-import com.bamdoliro.maru.domain.user.domain.User;
-import com.bamdoliro.maru.domain.user.service.UserFacade;
 import com.bamdoliro.maru.infrastructure.persistence.auth.TokenRepository;
 import com.bamdoliro.maru.shared.config.properties.JwtProperties;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -31,7 +29,6 @@ public class TokenService {
 
     private final JwtProperties jwtProperties;
     private final TokenRepository tokenRepository;
-    private final UserFacade userFacade;
 
     public String generateAccessToken(String uuid) {
         return generateToken(uuid, TokenType.ACCESS_TOKEN, jwtProperties.getAccessExpirationTime());
@@ -60,10 +57,6 @@ public class TokenService {
                 .setExpiration(new Date(now.getTime() + time))
                 .signWith(getSigningKey(jwtProperties.getSecretKey()), SignatureAlgorithm.HS256)
                 .compact();
-    }
-
-    public User getUser(String token) {
-        return userFacade.getUser(getUuid(token));
     }
 
     public String getUuid(String token) {

--- a/src/main/java/com/bamdoliro/maru/shared/auth/AuthenticationArgumentResolver.java
+++ b/src/main/java/com/bamdoliro/maru/shared/auth/AuthenticationArgumentResolver.java
@@ -1,7 +1,6 @@
 package com.bamdoliro.maru.shared.auth;
 
 import com.bamdoliro.maru.domain.auth.exception.AuthorityMismatchException;
-import com.bamdoliro.maru.domain.auth.service.TokenService;
 import com.bamdoliro.maru.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
@@ -17,8 +16,7 @@ import java.util.Objects;
 @Component
 public class AuthenticationArgumentResolver implements HandlerMethodArgumentResolver {
 
-    private final AuthenticationExtractor authenticationExtractor;
-    private final TokenService tokenService;
+    private final AuthenticationService authenticationService;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -28,8 +26,9 @@ public class AuthenticationArgumentResolver implements HandlerMethodArgumentReso
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
-        String token = authenticationExtractor.extract(webRequest);
-        User user = tokenService.getUser(token);
+
+        User user = authenticationService.getCurrentUser(webRequest);
+
         validateAuthority(user, Objects.requireNonNull(parameter.getParameterAnnotation(AuthenticationPrincipal.class)));
 
         return user;

--- a/src/main/java/com/bamdoliro/maru/shared/auth/AuthenticationService.java
+++ b/src/main/java/com/bamdoliro/maru/shared/auth/AuthenticationService.java
@@ -1,0 +1,24 @@
+package com.bamdoliro.maru.shared.auth;
+
+import com.bamdoliro.maru.domain.auth.service.TokenService;
+import com.bamdoliro.maru.domain.user.domain.User;
+import com.bamdoliro.maru.domain.user.service.UserFacade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.NativeWebRequest;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticationService {
+
+    private final AuthenticationExtractor authenticationExtractor;
+    private final TokenService tokenService;
+    private final UserFacade userFacade;
+
+    public User getCurrentUser(NativeWebRequest webRequest) {
+        String token = authenticationExtractor.extract(webRequest);
+        String phoneNumber = tokenService.getUuid(token);
+        return userFacade.getUser(phoneNumber);
+    }
+
+}

--- a/src/test/java/com/bamdoliro/maru/presentation/school/SchoolControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/presentation/school/SchoolControllerTest.java
@@ -1,9 +1,7 @@
 package com.bamdoliro.maru.presentation.school;
 
-import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.shared.fixture.AuthFixture;
 import com.bamdoliro.maru.shared.fixture.SchoolFixture;
-import com.bamdoliro.maru.shared.fixture.UserFixture;
 import com.bamdoliro.maru.shared.util.RestDocsTestSupport;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
@@ -24,10 +22,8 @@ class SchoolControllerTest extends RestDocsTestSupport {
 
     @Test
     void 학교를_검색한다() throws Exception {
-        User user = UserFixture.createUser();
         given(searchSchoolUseCase.execute(anyString())).willReturn(SchoolFixture.createSchoolListResponse());
         given(jwtProperties.getPrefix()).willReturn("Bearer");
-        given(tokenService.getUser(anyString())).willReturn(user);
 
 
         mockMvc.perform(get("/schools")
@@ -51,10 +47,8 @@ class SchoolControllerTest extends RestDocsTestSupport {
 
     @Test
     void 학교를_검색할_때_결과가_10개_이상이라면_상위_10개만_반환한다() throws Exception {
-        User user = UserFixture.createUser();
         given(searchSchoolUseCase.execute(anyString())).willReturn(SchoolFixture.createSchoolMaxListResponse());
         given(jwtProperties.getPrefix()).willReturn("Bearer");
-        given(tokenService.getUser(anyString())).willReturn(user);
 
 
         mockMvc.perform(get("/schools")
@@ -69,10 +63,8 @@ class SchoolControllerTest extends RestDocsTestSupport {
 
     @Test
     void 학교를_검색할_때_결과가_없다면_빈_리스트를_반환한다() throws Exception {
-        User user = UserFixture.createUser();
         given(searchSchoolUseCase.execute(anyString())).willReturn(List.of());
         given(jwtProperties.getPrefix()).willReturn("Bearer");
-        given(tokenService.getUser(anyString())).willReturn(user);
 
 
         mockMvc.perform(get("/schools")


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #332

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> AuthenticationService 클래스를 만들어 책임을 분리하였습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- AuthenticaitonService를 만들어 User를 찾는 책임을 분리하였습니다.
- 사용하지 않는 getUser 메서드와 해당되는 메서드가 사용되는 부분을 지웠습니다.


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [ ] 테스트를 완료했나요?
- [ ] API 문서를 작성했나요?
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

