### PR TITLE
[새기능] 과목별 상세 정보를 담은 합격자 내보내기 기능 추가

### DIFF
--- a/src/docs/asciidoc/form.adoc
+++ b/src/docs/asciidoc/form.adoc
@@ -745,3 +745,20 @@ include::{snippets}/form-controller-test/자동으로_2차_합격_여부를_결�
 
 ===== 최종 점수가 없는 원서가 있을 경우
 include::{snippets}/form-controller-test/자동으로_2차_합격_여부를_결정할_때_최종_점수가_없는_원서가_존재하면_에러가_발생한다/http-response.adoc[]
+
+
+=== 과목별 성적 상세 엑셀 다운로드
+어드민은 합격자들의 과목별 성적 상세 정보를 엑셀로 다운로드 받을 수 있습니다.
+
+==== 요청 형식
+
+===== Request Header
+include::{snippets}/form-controller-test/정상적으로_과목별_성적_상세를_다운로드한다/request-headers.adoc[]
+
+==== 요청
+include::{snippets}/form-controller-test/정상적으로_과목별_성적_상세를_다운로드한다/http-request.adoc[]
+
+==== 응답
+
+===== 정상 응답
+include::{snippets}/form-controller-test/정상적으로_과목별_성적_상세를_다운로드한다/http-response.adoc[]

--- a/src/main/java/com/bamdoliro/maru/application/form/ExportSubjectGradeDetailUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/ExportSubjectGradeDetailUseCase.java
@@ -1,0 +1,138 @@
+package com.bamdoliro.maru.application.form;
+
+import com.bamdoliro.maru.domain.form.domain.Form;
+import com.bamdoliro.maru.domain.form.domain.type.FormStatus;
+import com.bamdoliro.maru.domain.form.domain.value.Subject;
+import com.bamdoliro.maru.domain.form.service.FormFacade;
+import com.bamdoliro.maru.infrastructure.xlsx.XlsxGenerator;
+import com.bamdoliro.maru.shared.annotation.UseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+
+import java.io.IOException;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+@RequiredArgsConstructor
+@UseCase
+public class ExportSubjectGradeDetailUseCase {
+
+    private final FormFacade formFacade;
+    private final XlsxGenerator xlsxGenerator;
+
+    public Resource execute() throws IOException {
+        List<Form> formList = formFacade.getSortedFormList(FormStatus.ENTERED);
+
+        Set<String> allSubjects = extractAllSubjects(formList);
+
+        List<String> headers = buildHeaders(allSubjects);
+        List<Function<Form, Object>> columnList = buildColumnList(allSubjects);
+        List<String> styleList = buildStyleList(allSubjects);
+
+        return xlsxGenerator.executeWithDynamicHeaders(headers, formList, columnList, styleList);
+    }
+
+    private Set<String> extractAllSubjects(List<Form> formList) {
+        Set<String> allSubjects = new LinkedHashSet<>();
+
+        for (Form form : formList) {
+            List<Subject> subjects = form.getGrade().getSubjectListValue();
+            for (Subject subject : subjects) {
+                String subjectKey = String.format("%d%d_%s",
+                    subject.getGrade(),
+                    subject.getSemester(),
+                    subject.getSubjectName());
+                allSubjects.add(subjectKey);
+            }
+        }
+
+        return allSubjects;
+    }
+
+    private List<String> buildHeaders(Set<String> allSubjects) {
+        List<String> headers = new ArrayList<>();
+
+        headers.add("ID");
+        headers.add("수험번호");
+        headers.add("이름");
+        headers.add("전화번호");
+        headers.add("생년월일");
+        headers.add("학교명");
+
+        for (String subjectKey : allSubjects) {
+            String[] parts = subjectKey.split("_");
+            if (parts.length == 2) {
+                String gradeSemester = parts[0];
+                String subjectName = parts[1];
+                headers.add(String.format("%s학년 %s학기 %s",
+                    gradeSemester.substring(0, 1),
+                    gradeSemester.substring(1, 2),
+                    subjectName));
+            }
+        }
+
+        return headers;
+    }
+
+    private List<Function<Form, Object>> buildColumnList(Set<String> allSubjects) {
+        List<Function<Form, Object>> columnList = new ArrayList<>();
+
+        columnList.add(Form::getId);
+        columnList.add(Form::getExaminationNumber);
+        columnList.add(form -> form.getApplicant().getName());
+        columnList.add(form -> form.getApplicant().getPhoneNumber().toString());
+        columnList.add(form -> form.getApplicant().getBirthday().format(DateTimeFormatter.BASIC_ISO_DATE));
+        columnList.add(form -> form.getEducation().getSchool().getName());
+
+        for (String subjectKey : allSubjects) {
+            columnList.add(form -> getSubjectScore(form, subjectKey));
+        }
+
+        return columnList;
+    }
+
+    private List<String> buildStyleList(Set<String> allSubjects) {
+        List<String> styleList = new ArrayList<>();
+
+        styleList.add("default");
+        styleList.add("default");
+        styleList.add("default");
+        styleList.add("default");
+        styleList.add("default");
+        styleList.add("default");
+
+        for (String ignored : allSubjects) {
+            styleList.add("right");
+        }
+
+        return styleList;
+    }
+
+    private Object getSubjectScore(Form form, String subjectKey) {
+        String[] parts = subjectKey.split("_");
+        if (parts.length != 2) return "";
+
+        String gradeSemester = parts[0];
+        String subjectName = parts[1];
+
+        if (gradeSemester.length() != 2) return "";
+
+        int grade = Integer.parseInt(gradeSemester.substring(0, 1));
+        int semester = Integer.parseInt(gradeSemester.substring(1, 2));
+
+        List<Subject> subjects = form.getGrade().getSubjectListValue();
+        for (Subject subject : subjects) {
+            if (subject.getGrade().equals(grade) &&
+                subject.getSemester().equals(semester) &&
+                subject.getSubjectName().equals(subjectName)) {
+                return subject.getAchievementLevel().getDescription();
+            }
+        }
+
+        return "";
+    }
+}

--- a/src/main/java/com/bamdoliro/maru/infrastructure/xlsx/XlsxGenerator.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/xlsx/XlsxGenerator.java
@@ -43,6 +43,35 @@ public class XlsxGenerator {
         return xlsxService.convertToByteArrayResource(workbook);
     }
 
+    public Resource executeWithDynamicHeaders(List<String> headers, List<Form> formList, List<Function<Form, Object>> columnList, List<String> styleList) throws IOException {
+        Workbook workbook = new org.apache.poi.xssf.usermodel.XSSFWorkbook();
+        Sheet sheet = workbook.createSheet();
+
+        Map<String, CellStyle> styleMap = Map.of(
+                "default", xlsxService.createDefaultCellStyle(workbook),
+                "right", xlsxService.createRightCellStyle(workbook),
+                "empty", xlsxService.createEmptyCellStyle(workbook),
+                "date", xlsxService.createDateCellStyle(workbook)
+        );
+
+        Row headerRow = sheet.createRow(0);
+        for (int i = 0; i < headers.size(); i++) {
+            createCell(headerRow, i, headers.get(i), styleMap.get("default"));
+        }
+
+        for (int index = 0; index < formList.size(); index++) {
+            Form form = formList.get(index);
+            Row row = sheet.createRow(index + 1);
+            int columnIndex = 0;
+
+            for (Function<Form, Object> column : columnList) {
+                createCell(row, columnIndex, column.apply(form), styleMap.get(styleList.get(columnIndex++)));
+            }
+        }
+
+        return xlsxService.convertToByteArrayResource(workbook);
+    }
+
     private void createCell(Row row, int cellIndex, Object value, CellStyle style) {
         Cell cell = row.createCell(cellIndex);
         if (value instanceof Integer)

--- a/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
@@ -25,6 +25,8 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -59,6 +61,7 @@ public class FormController {
     private final ExportFirstRoundResultUseCase exportFirstRoundResultUseCase;
     private final ExportSecondRoundResultUseCase exportSecondRoundResultUseCase;
     private final ExportResultUseCase exportResultUseCase;
+    private final ExportSubjectGradeDetailUseCase exportSubjectGradeDetailUseCase;
     private final PassOrFailFormUseCase passOrFailFormUseCase;
     private final QueryFormUrlUseCase queryFormUrlUseCase;
     private final SelectSecondPassUseCase selectSecondPassUseCase;
@@ -329,6 +332,22 @@ public class FormController {
         return ResponseEntity.ok()
                 .contentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
                 .body(exportResultUseCase.execute());
+    }
+
+    @GetMapping("/xlsx/subject-grade-detail")
+    public ResponseEntity<Resource> exportSubjectGradeDetail(
+            @AuthenticationPrincipal(authority = Authority.ADMIN) User user
+    )  throws IOException {
+        String filename = "합격자성적상세.xlsx";
+        String encodedFilename = URLEncoder.encode(filename, StandardCharsets.UTF_8)
+                .replace("+", "%20");
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType(
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
+                .header("Content-Disposition",
+                        "attachment; filename=\"export.xlsx\"; filename*=UTF-8''" + encodedFilename)
+                .body(exportSubjectGradeDetailUseCase.execute());
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/test/java/com/bamdoliro/maru/application/form/ExportSubjectGradeDetailUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/ExportSubjectGradeDetailUseCaseTest.java
@@ -1,0 +1,62 @@
+package com.bamdoliro.maru.application.form;
+
+import com.bamdoliro.maru.domain.form.domain.Form;
+import com.bamdoliro.maru.domain.form.service.AssignExaminationNumberService;
+import com.bamdoliro.maru.domain.form.service.CalculateFormScoreService;
+import com.bamdoliro.maru.domain.user.domain.User;
+import com.bamdoliro.maru.infrastructure.persistence.form.FormRepository;
+import com.bamdoliro.maru.infrastructure.persistence.user.UserRepository;
+import com.bamdoliro.maru.shared.config.DatabaseClearExtension;
+import com.bamdoliro.maru.shared.constants.FixedNumber;
+import com.bamdoliro.maru.shared.fixture.FormFixture;
+import com.bamdoliro.maru.shared.fixture.UserFixture;
+import com.bamdoliro.maru.shared.util.SaveFileUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+@ActiveProfiles("test")
+@ExtendWith(DatabaseClearExtension.class)
+@SpringBootTest
+class ExportSubjectGradeDetailUseCaseTest {
+
+    @Autowired
+    private ExportSubjectGradeDetailUseCase exportSubjectGradeDetailUseCase;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private AssignExaminationNumberService assignExaminationNumberService;
+
+    @Autowired
+    private FormRepository formRepository;
+
+    @Autowired
+    private CalculateFormScoreService calculateFormScoreService;
+
+    @BeforeEach
+    void setUp() {
+        List<User> userList = userRepository.saveAll(
+                UserFixture.generateUserList(FixedNumber.TOTAL)
+        );
+        List<Form> formList = FormFixture.generateBusanFormList(userList);
+        formList.forEach(form -> {
+            assignExaminationNumberService.execute(form);
+            form.pass();
+            calculateFormScoreService.execute(form);
+            form.getScore().updateSecondRoundMeisterScore(100.2, 10.4, 100.7);
+            formRepository.save(form);
+        });
+    }
+
+    @Test
+    void 과목별_성적_상세를_엑셀로_저장한다() throws Exception {
+        SaveFileUtil.execute(exportSubjectGradeDetailUseCase.execute(), SaveFileUtil.XLSX);
+    }
+}

--- a/src/test/java/com/bamdoliro/maru/presentation/form/FormControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/presentation/form/FormControllerTest.java
@@ -1,6 +1,7 @@
 package com.bamdoliro.maru.presentation.form;
 
 import com.bamdoliro.maru.application.form.ExportFirstScoreUseCase;
+import com.bamdoliro.maru.application.form.ExportSubjectGradeDetailUseCase;
 import com.bamdoliro.maru.domain.auth.exception.AuthorityMismatchException;
 import com.bamdoliro.maru.domain.form.domain.Form;
 import com.bamdoliro.maru.domain.form.domain.type.FormStatus;
@@ -49,6 +50,9 @@ class FormControllerTest extends RestDocsTestSupport {
 
     @Autowired
     private ExportFirstScoreUseCase exportFirstScoreUseCase;
+
+    @Autowired
+    private ExportSubjectGradeDetailUseCase exportSubjectGradeDetailUseCase;
 
     @Test
     void 원서를_제출한다() throws Exception {
@@ -2436,5 +2440,35 @@ class FormControllerTest extends RestDocsTestSupport {
                 ));
 
         verify(exportFirstScoreUseCase, times(1)).execute();
+    }
+
+    @Test
+    void 정상적으로_과목별_성적_상세를_다운로드한다() throws Exception {
+        User user = UserFixture.createAdminUser();
+        MockMultipartFile file = new MockMultipartFile(
+                "과목별성적상세",
+                "과목별성적상세.xlsx",
+                String.valueOf(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")),
+                "<<file>>".getBytes()
+        );
+
+        given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
+        given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
+        given(exportSubjectGradeDetailUseCase.execute()).willReturn(new ByteArrayResource(file.getBytes()));
+
+        mockMvc.perform(get("/forms/xlsx/subject-grade-detail")
+                        .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
+                        .accept("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
+
+                .andExpect(status().isOk())
+
+                .andDo(restDocs.document(
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION)
+                                        .description("Bearer token")
+                        )
+                ));
+
+        verify(exportSubjectGradeDetailUseCase, times(1)).execute();
     }
 }

--- a/src/test/java/com/bamdoliro/maru/shared/util/ControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/shared/util/ControllerTest.java
@@ -205,6 +205,9 @@ public abstract class ControllerTest {
     protected DeleteQuestionUseCase deleteQuestionUseCase;
 
     @MockitoBean
+    protected ExportSubjectGradeDetailUseCase exportSubjectGradeDetailUseCase;
+
+    @MockitoBean
     protected ExportFinalPassedFormUseCase exportFinalPassedFormUseCase;
 
     @MockitoBean


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #334

<br>

## 📄 개요

> 합격자 성적 상세 정보 액셀로 내보내기 기능을 추가했습니다.

<br>

## 🔨 작업 내용

- ExportSubjectGradeDetailUseCase를 만들어 합격자 성적 상세 정보를 액셀로 내보내도록 했습니다.


<br>

## 🏁 확인 사항
- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말