### PR TITLE
[개선] 합격자 성적 상세 내보내기 타입 변경

### DIFF
--- a/src/main/java/com/bamdoliro/maru/application/form/ExportSubjectGradeDetailUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/ExportSubjectGradeDetailUseCase.java
@@ -25,7 +25,7 @@ public class ExportSubjectGradeDetailUseCase {
     private final XlsxGenerator xlsxGenerator;
 
     public Resource execute() throws IOException {
-        List<Form> formList = formFacade.getSortedFormList(FormStatus.ENTERED);
+        List<Form> formList = formFacade.getSortedFormList(FormStatus.PASSED);
 
         Set<String> allSubjects = extractAllSubjects(formList);
 

--- a/src/main/java/com/bamdoliro/maru/application/form/ExportSubjectGradeDetailUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/ExportSubjectGradeDetailUseCase.java
@@ -8,6 +8,7 @@ import com.bamdoliro.maru.infrastructure.xlsx.XlsxGenerator;
 import com.bamdoliro.maru.shared.annotation.UseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.Resource;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.time.format.DateTimeFormatter;
@@ -24,6 +25,7 @@ public class ExportSubjectGradeDetailUseCase {
     private final FormFacade formFacade;
     private final XlsxGenerator xlsxGenerator;
 
+    @Transactional(readOnly = true)
     public Resource execute() throws IOException {
         List<Form> formList = formFacade.getSortedFormList(FormStatus.PASSED);
 


### PR DESCRIPTION
## 🎫 관련 이슈

close #336

<br>

## 📄 개요

> 올해 입학등록원을 직접 내기에 상세 내보내기의 타입을 변경했습니다.

<br>

## 🔨 작업 내용

- 타입을 ENTERED에서 PASSED로 변경했습니다.


<br>

## 🏁 확인 사항
- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말