### PR TITLE
[개선] 헤더 제거

### DIFF
--- a/src/main/java/com/bamdoliro/maru/presentation/auth/AuthController.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/auth/AuthController.java
@@ -41,13 +41,9 @@ public class AuthController {
 
     @PatchMapping
     public SingleCommonResponse<TokenResponse> refreshToken(
-            @CookieValue(value = "refreshToken", required = false) String refreshTokenFromCookie,
-            @RequestHeader(value = "Refresh-Token", required = false) String refreshTokenFromHeader,
+            @CookieValue(value = "refreshToken") String refreshToken,
             HttpServletResponse response
     ) {
-        String refreshToken = refreshTokenFromCookie != null
-                ? refreshTokenFromCookie
-                : refreshTokenFromHeader;
 
         TokenResponse tokenResponse = refreshTokenUseCase.execute(refreshToken);
 

--- a/src/test/java/com/bamdoliro/maru/presentation/auth/AuthControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/presentation/auth/AuthControllerTest.java
@@ -10,7 +10,6 @@ import com.bamdoliro.maru.presentation.auth.dto.response.TokenResponse;
 import com.bamdoliro.maru.shared.fixture.AuthFixture;
 import com.bamdoliro.maru.shared.fixture.UserFixture;
 import com.bamdoliro.maru.shared.util.RestDocsTestSupport;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpHeaders;
@@ -169,7 +168,6 @@ class AuthControllerTest extends RestDocsTestSupport {
                 .andDo(restDocs.document());
     }
 
-    @Disabled("프론트 마이그레이션 기간동안은 잠시 disabled")
     @Test
     void 액세스_토큰을_재발급할_때_리프레시_토큰을_보내지_않으면_에러가_발생한다() throws Exception {
 

--- a/src/test/java/com/bamdoliro/maru/presentation/auth/AuthControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/presentation/auth/AuthControllerTest.java
@@ -10,6 +10,7 @@ import com.bamdoliro.maru.presentation.auth.dto.response.TokenResponse;
 import com.bamdoliro.maru.shared.fixture.AuthFixture;
 import com.bamdoliro.maru.shared.fixture.UserFixture;
 import com.bamdoliro.maru.shared.util.RestDocsTestSupport;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpHeaders;
@@ -24,6 +25,8 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
@@ -123,14 +126,14 @@ class AuthControllerTest extends RestDocsTestSupport {
         mockMvc.perform(patch("/auth")
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .header("Refresh-Token", refreshToken)
+                        .cookie(new Cookie("refreshToken", refreshToken))
                 )
 
                 .andExpect(status().is2xxSuccessful())
 
                 .andDo(restDocs.document(
-                        requestHeaders(
-                                headerWithName("Refresh-Token")
+                        requestCookies(
+                                cookieWithName("refreshToken")
                                         .description("리프레시 토큰")
                         )
                 ));
@@ -144,7 +147,7 @@ class AuthControllerTest extends RestDocsTestSupport {
         mockMvc.perform(patch("/auth")
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .header("Refresh-Token", expiredRefreshToken)
+                        .cookie(new Cookie("refreshToken", expiredRefreshToken))
                 )
 
                 .andExpect(status().isUnauthorized())
@@ -160,7 +163,7 @@ class AuthControllerTest extends RestDocsTestSupport {
         mockMvc.perform(patch("/auth")
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .header("Refresh-Token", accessToken)
+                        .cookie(new Cookie("refreshToken", accessToken))
                 )
 
                 .andExpect(status().isUnauthorized())
@@ -191,7 +194,7 @@ class AuthControllerTest extends RestDocsTestSupport {
         mockMvc.perform(patch("/auth")
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .header("Refresh-Token", accessToken)
+                        .cookie(new Cookie("refreshToken", accessToken))
                 )
 
                 .andExpect(status().isUnauthorized())


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #368

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 오로지 쿠키로만 토큰 재발급이 하도록 변경하였습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- patch /auth 에서 기존의 리프레시 헤더를 제거했어요.
- 쿠키 밸류를 추가하여 쿠키를 통해 값을 전달받도록 수정했어요.


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [ ] 테스트를 완료했나요?
- [ ] API 문서를 작성했나요?
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

