### PR TITLE
[새기능] 입학설명회 삭제/수정

### DIFF
--- a/src/docs/asciidoc/fair.adoc
+++ b/src/docs/asciidoc/fair.adoc
@@ -109,3 +109,49 @@ include::{snippets}/admin-fair-controller-test/입학설명회_신청자_명단�
 
 ===== 입학설명회가 없는 경우
 include::{snippets}/admin-fair-controller-test/입학설명회_신청자_명단을_엑셀로_다운받을_때_입학설명회가_없으면_에러가_발생한다/http-response.adoc[]
+
+
+=== 입학설명회 일정 수정
+어드민은 입학설명회 일정을 수정할 수 있습니다.
+
+==== 요청 형식
+
+===== Request Cookie
+include::{snippets}/admin-fair-controller-test/입학설명회를_수정한다/request-cookies.adoc[]
+
+===== Path Parameter
+include::{snippets}/admin-fair-controller-test/입학설명회를_수정한다/path-parameters.adoc[]
+
+===== Request Body
+include::{snippets}/admin-fair-controller-test/입학설명회를_수정한다/request-fields.adoc[]
+
+===== 요청
+include::{snippets}/admin-fair-controller-test/입학설명회를_수정한다/http-request.adoc[]
+
+==== 응답
+
+===== 정상 응답
+include::{snippets}/admin-fair-controller-test/입학설명회를_수정한다/http-response.adoc[]
+
+===== 입학설명회가 없는 경우
+include::{snippets}/admin-fair-controller-test/입학설명회를_수정할_때_입학설명회가_없으면_에러가_발생한다/http-response.adoc[]
+
+
+=== 입학설명회 일정 삭제
+어드민은 입학설명회 일정을 삭제할 수 있습니다.
+
+==== 요청 형식
+
+===== Request Cookie
+include::{snippets}/admin-fair-controller-test/입학설명회를_삭제한다/request-cookies.adoc[]
+
+===== Path Parameter
+include::{snippets}/admin-fair-controller-test/입학설명회를_삭제한다/path-parameters.adoc[]
+
+==== 요청
+include::{snippets}/admin-fair-controller-test/입학설명회를_삭제한다/http-request.adoc[]
+
+==== 응답
+
+===== 정상 응답
+include::{snippets}/admin-fair-controller-test/입학설명회를_삭제한다/http-response.adoc[]

--- a/src/main/java/com/bamdoliro/maru/application/fair/DeleteAdmissionFairUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/fair/DeleteAdmissionFairUseCase.java
@@ -1,0 +1,14 @@
+package com.bamdoliro.maru.application.fair;
+
+import com.bamdoliro.maru.infrastructure.persistence.fair.FairRepository;
+import com.bamdoliro.maru.shared.annotation.UseCase;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@UseCase
+public class DeleteAdmissionFairUseCase {
+
+    private final FairRepository fairRepository;
+
+    public void execute(Long fairId) { fairRepository.deleteById(fairId); }
+}

--- a/src/main/java/com/bamdoliro/maru/application/fair/DeleteAdmissionFairUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/fair/DeleteAdmissionFairUseCase.java
@@ -10,5 +10,7 @@ public class DeleteAdmissionFairUseCase {
 
     private final FairRepository fairRepository;
 
-    public void execute(Long fairId) { fairRepository.deleteById(fairId); }
+    public void execute(Long fairId) {
+        fairRepository.deleteById(fairId);
+    }
 }

--- a/src/main/java/com/bamdoliro/maru/application/fair/UpdateAdmissionFairUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/fair/UpdateAdmissionFairUseCase.java
@@ -1,0 +1,20 @@
+package com.bamdoliro.maru.application.fair;
+
+import com.bamdoliro.maru.domain.fair.domain.Fair;
+import com.bamdoliro.maru.presentation.fair.dto.request.UpdateFairRequest;
+import com.bamdoliro.maru.shared.annotation.UseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@UseCase
+public class UpdateAdmissionFairUseCase {
+
+    private final FairFacade fairFacade;
+
+    @Transactional
+    public void execute(Long id, UpdateFairRequest request) {
+        Fair fair = fairFacade.getFair(id);
+        fair.update(request.getStart(), request.getCapacity(), request.getPlace(), request.getType(), request.getApplicationStartDate(), request.getApplicationEndDate());
+    }
+}

--- a/src/main/java/com/bamdoliro/maru/domain/fair/domain/Fair.java
+++ b/src/main/java/com/bamdoliro/maru/domain/fair/domain/Fair.java
@@ -45,7 +45,7 @@ public class Fair extends BaseTimeEntity {
     private LocalDate applicationEndDate;
 
 
-    @OneToMany(mappedBy = "fair", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "fair", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private final List<Attendee> attendeeList = new ArrayList<>();
 
     @Builder

--- a/src/main/java/com/bamdoliro/maru/domain/fair/domain/Fair.java
+++ b/src/main/java/com/bamdoliro/maru/domain/fair/domain/Fair.java
@@ -58,6 +58,15 @@ public class Fair extends BaseTimeEntity {
         this.applicationEndDate = applicationEndDate;
     }
 
+    public void update(LocalDateTime start, Integer capacity, String place, FairType type, LocalDate applicationStartDate, LocalDate applicationEndDate) {
+        this.start = start;
+        this.capacity = capacity;
+        this.place = place;
+        this.type = type;
+        this.applicationStartDate = applicationStartDate;
+        this.applicationEndDate = applicationEndDate;
+    }
+
     public FairStatus getStatus(Integer headcount) {
         LocalDateTime now = LocalDateTime.now();
         if (now.isAfter(start)) {

--- a/src/main/java/com/bamdoliro/maru/presentation/fair/AdminFairController.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/fair/AdminFairController.java
@@ -1,10 +1,9 @@
 package com.bamdoliro.maru.presentation.fair;
 
-import com.bamdoliro.maru.application.fair.CreateAdmissionFairUseCase;
-import com.bamdoliro.maru.application.fair.ExportAttendeeListUseCase;
-import com.bamdoliro.maru.application.fair.QueryFairDetailUseCase;
+import com.bamdoliro.maru.application.fair.*;
 import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.presentation.fair.dto.request.CreateFairRequest;
+import com.bamdoliro.maru.presentation.fair.dto.request.UpdateFairRequest;
 import com.bamdoliro.maru.presentation.fair.dto.response.FairDetailResponse;
 import com.bamdoliro.maru.shared.auth.AuthenticationPrincipal;
 import com.bamdoliro.maru.shared.auth.Authority;
@@ -26,6 +25,8 @@ import java.io.IOException;
 public class AdminFairController {
 
     private final CreateAdmissionFairUseCase createAdmissionFairUseCase;
+    private final UpdateAdmissionFairUseCase updateAdmissionFairUseCase;
+    private final DeleteAdmissionFairUseCase deleteAdmissionFairUseCase;
     private final QueryFairDetailUseCase queryFairDetailUseCase;
     private final ExportAttendeeListUseCase exportAttendeeListUseCase;
 
@@ -56,6 +57,25 @@ public class AdminFairController {
         return ResponseEntity.ok()
                 .contentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
                 .body(exportAttendeeListUseCase.execute(fairId));
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PutMapping("/{fair-id}")
+    public void updateQuestion(
+            @AuthenticationPrincipal(authority = Authority.ADMIN) User user,
+            @PathVariable(name = "fair-id") Long fairId,
+            @RequestBody @Valid UpdateFairRequest request
+    ) {
+        updateAdmissionFairUseCase.execute(fairId, request);
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/{fair-id}")
+    public void deleteQuestion(
+            @AuthenticationPrincipal(authority = Authority.ADMIN) User user,
+            @PathVariable(name = "fair-id") Long fairId
+    ) {
+        deleteAdmissionFairUseCase.execute(fairId);
     }
 
 }

--- a/src/main/java/com/bamdoliro/maru/presentation/fair/dto/request/UpdateFairRequest.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/fair/dto/request/UpdateFairRequest.java
@@ -1,0 +1,39 @@
+package com.bamdoliro.maru.presentation.fair.dto.request;
+
+import com.bamdoliro.maru.domain.fair.domain.type.FairType;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateFairRequest {
+
+    @NotNull(message = "필수값입니다.")
+    private LocalDateTime start;
+
+    @NotNull(message = "필수값입니다.")
+    @Min(value = 1, message = "1 이상이어야 합니다.")
+    private Integer capacity;
+
+    @NotBlank(message = "필수값입니다.")
+    @Size(max = 30, message = "30자 이하여야 합니다.")
+    private String place;
+
+    @NotNull(message = "필수값입니다.")
+    private FairType type;
+
+    @NotNull(message = "필수값입니다.")
+    private LocalDate applicationStartDate;
+
+    @NotNull(message = "필수값입니다.")
+    private LocalDate applicationEndDate;
+}

--- a/src/test/java/com/bamdoliro/maru/application/fair/DeleteAdmissionFairUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/fair/DeleteAdmissionFairUseCaseTest.java
@@ -20,7 +20,7 @@ class DeleteAdmissionFairUseCaseTest {
     private FairRepository fairRepository;
 
     @Test
-    void 입학설명회_삭제() {
+    void 입학설명회를_삭제한다() {
         // given
         Long id = 1L;
         willDoNothing().given(fairRepository).deleteById(id);

--- a/src/test/java/com/bamdoliro/maru/application/fair/DeleteAdmissionFairUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/fair/DeleteAdmissionFairUseCaseTest.java
@@ -1,0 +1,34 @@
+package com.bamdoliro.maru.application.fair;
+
+import com.bamdoliro.maru.infrastructure.persistence.fair.FairRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class DeleteAdmissionFairUseCaseTest {
+
+    @InjectMocks
+    private DeleteAdmissionFairUseCase deleteAdmissionFairUseCase;
+
+    @Mock
+    private FairRepository fairRepository;
+
+    @Test
+    void 입학설명회_삭제() {
+        // given
+        Long id = 1L;
+        willDoNothing().given(fairRepository).deleteById(id);
+
+        // when
+        deleteAdmissionFairUseCase.execute(id);
+
+        // then
+        verify(fairRepository).deleteById(id);
+    }
+}

--- a/src/test/java/com/bamdoliro/maru/application/fair/DeleteAdmissionFairUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/fair/DeleteAdmissionFairUseCaseTest.java
@@ -11,7 +11,7 @@ import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-public class DeleteAdmissionFairUseCaseTest {
+class DeleteAdmissionFairUseCaseTest {
 
     @InjectMocks
     private DeleteAdmissionFairUseCase deleteAdmissionFairUseCase;

--- a/src/test/java/com/bamdoliro/maru/application/fair/UpdateAdmissionFairUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/fair/UpdateAdmissionFairUseCaseTest.java
@@ -1,0 +1,55 @@
+package com.bamdoliro.maru.application.fair;
+
+import com.bamdoliro.maru.domain.fair.domain.Fair;
+import com.bamdoliro.maru.domain.fair.domain.type.FairType;
+import com.bamdoliro.maru.presentation.fair.dto.request.UpdateFairRequest;
+import com.bamdoliro.maru.shared.fixture.FairFixture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(SpringExtension.class)
+public class UpdateAdmissionFairUseCaseTest {
+
+    @InjectMocks
+    private UpdateAdmissionFairUseCase updateAdmissionFairUseCase;
+
+    @Mock
+    private FairFacade fairFacade;
+
+    @Test
+    public void 입학설명회_수정() {
+        // given
+        Fair fair = FairFixture.createFair();
+        LocalDateTime time = LocalDateTime.of(2026, 4, 13, 8, 19, 41);
+        LocalDate date = LocalDate.of(3939, 3, 9);
+        UpdateFairRequest request = new UpdateFairRequest(time, 100, "부산소프트웨어마이스터고등학교 어딘가", FairType.TEACHER, date, date);
+
+        given(fairFacade.getFair(fair.getId())).willReturn(fair);
+
+        // when
+        updateAdmissionFairUseCase.execute(fair.getId(), request);
+
+        // then
+        verify(fairFacade).getFair(fair.getId());
+
+        assertAll(
+                () -> assertEquals(request.getStart(), fair.getStart()),
+                () -> assertEquals(request.getCapacity(), fair.getCapacity()),
+                () -> assertEquals(request.getPlace(), fair.getPlace()),
+                () -> assertEquals(request.getType(), fair.getType()),
+                () -> assertEquals(request.getApplicationStartDate(), fair.getApplicationStartDate()),
+                () -> assertEquals(request.getApplicationEndDate(), fair.getApplicationEndDate())
+        );
+    }
+}

--- a/src/test/java/com/bamdoliro/maru/application/fair/UpdateAdmissionFairUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/fair/UpdateAdmissionFairUseCaseTest.java
@@ -19,7 +19,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(SpringExtension.class)
-public class UpdateAdmissionFairUseCaseTest {
+class UpdateAdmissionFairUseCaseTest {
 
     @InjectMocks
     private UpdateAdmissionFairUseCase updateAdmissionFairUseCase;
@@ -28,7 +28,7 @@ public class UpdateAdmissionFairUseCaseTest {
     private FairFacade fairFacade;
 
     @Test
-    public void 입학설명회_수정() {
+    void 입학설명회_수정() {
         // given
         Fair fair = FairFixture.createFair();
         LocalDateTime time = LocalDateTime.of(2026, 4, 13, 8, 19, 41);

--- a/src/test/java/com/bamdoliro/maru/application/fair/UpdateAdmissionFairUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/fair/UpdateAdmissionFairUseCaseTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith(SpringExtension.class)
+@ExtendWith(MockitoExtension.class)
 class UpdateAdmissionFairUseCaseTest {
 
     @InjectMocks
@@ -28,7 +28,7 @@ class UpdateAdmissionFairUseCaseTest {
     private FairFacade fairFacade;
 
     @Test
-    void 입학설명회_수정() {
+    void 입학설명회를_수정한다() {
         // given
         Fair fair = FairFixture.createFair();
         LocalDateTime time = LocalDateTime.of(2026, 4, 13, 8, 19, 41);

--- a/src/test/java/com/bamdoliro/maru/presentation/fair/AdminFairControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/presentation/fair/AdminFairControllerTest.java
@@ -276,4 +276,28 @@ public class AdminFairControllerTest extends RestDocsTestSupport {
         verify(deleteAdmissionFairUseCase, times(1)).execute(fairId);
     }
 
+    @Test
+    void 입학설명회를_수정할_때_입학설명회가_없으면_에러가_발생한다() throws Exception {
+        Long fairId = 1L;
+        LocalDateTime time = LocalDateTime.of(2026, 4, 13, 8, 19, 41);
+        LocalDate date = LocalDate.of(3939, 3, 9);
+
+        UpdateFairRequest request = new UpdateFairRequest(time, 100, "부산소프트웨어마이스터고등학교 어딘가", FairType.TEACHER, date, date);
+        willThrow(new FairNotFoundException()).given(updateAdmissionFairUseCase).execute(eq(1L), any(UpdateFairRequest.class));
+
+        User user = UserFixture.createAdminUser();
+        given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
+        given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
+
+        mockMvc.perform(put("/admin/fairs/{fair-id}", fairId)
+                        .cookie(AuthFixture.createAuthCookie())
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(request)))
+
+                .andExpect(status().isNotFound())
+
+                .andDo(restDocs.document());
+    }
+
 }

--- a/src/test/java/com/bamdoliro/maru/presentation/fair/AdminFairControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/presentation/fair/AdminFairControllerTest.java
@@ -1,8 +1,10 @@
 package com.bamdoliro.maru.presentation.fair;
 
+import com.bamdoliro.maru.domain.fair.domain.type.FairType;
 import com.bamdoliro.maru.domain.fair.exception.FairNotFoundException;
 import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.presentation.fair.dto.request.CreateFairRequest;
+import com.bamdoliro.maru.presentation.fair.dto.request.UpdateFairRequest;
 import com.bamdoliro.maru.shared.fixture.AuthFixture;
 import com.bamdoliro.maru.shared.fixture.FairFixture;
 import com.bamdoliro.maru.shared.fixture.UserFixture;
@@ -14,6 +16,9 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.payload.JsonFieldType;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.BDDMockito.willThrow;
@@ -21,8 +26,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
 import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
@@ -184,6 +188,92 @@ public class AdminFairControllerTest extends RestDocsTestSupport {
                 .andDo(restDocs.document());
 
         verify(exportAttendeeListUseCase, times(1)).execute(fairId);
+    }
+
+    @Test
+    void 입학설명회를_수정한다() throws Exception {
+        Long fairId = 1L;
+        LocalDateTime time = LocalDateTime.of(2026, 4, 13, 8, 19, 41);
+        LocalDate date = LocalDate.of(3939, 3, 9);
+
+        UpdateFairRequest request = new UpdateFairRequest(time, 100, "부산소프트웨어마이스터고등학교 어딘가", FairType.TEACHER, date, date);
+        willDoNothing().given(updateAdmissionFairUseCase).execute(fairId, request);
+
+        User user = UserFixture.createAdminUser();
+        given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
+        given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
+
+        mockMvc.perform(put("/admin/fairs/{fair-id}", fairId)
+                        .cookie(AuthFixture.createAuthCookie())
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(request)))
+
+                .andExpect(status().isNoContent())
+
+                .andDo(restDocs.document(
+                        requestCookies(
+                                cookieWithName("accessToken")
+                                        .description("이것은.액세스.토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("fair-id")
+                                        .description("입학설명회 id")
+                        ),
+                        requestFields(
+                                fieldWithPath("start")
+                                        .type(JsonFieldType.STRING)
+                                        .description("입학설명회 일시 (yyyy-MM-ddThh:mm:ss)"),
+                                fieldWithPath("capacity")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("입학설명회 정원"),
+                                fieldWithPath("place")
+                                        .type(JsonFieldType.STRING)
+                                        .description("입학설명회 장소"),
+                                fieldWithPath("type")
+                                        .type(JsonFieldType.STRING)
+                                        .description("<<fair-type,입학설명회 유형>>"),
+                                fieldWithPath("applicationStartDate")
+                                        .type(JsonFieldType.STRING)
+                                        .optional()
+                                        .description("입학설명회 신청 시작일 (yyyy-MM-dd)"),
+                                fieldWithPath("applicationEndDate")
+                                        .type(JsonFieldType.STRING)
+                                        .optional()
+                                        .description("입학설명회 신청 종료일 (yyyy-MM-dd)")
+                        )
+                ));
+
+        verify(updateAdmissionFairUseCase, times(1)).execute(eq(fairId), any(UpdateFairRequest.class));
+    }
+
+    @Test
+    void 입학설명회를_삭제한다() throws Exception {
+        Long fairId = 1L;
+        willDoNothing().given(deleteAdmissionFairUseCase).execute(fairId);
+
+        User user = UserFixture.createAdminUser();
+        given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
+        given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
+
+        mockMvc.perform(delete("/admin/fairs/{fair-id}", fairId)
+                        .cookie(AuthFixture.createAuthCookie())
+                        .accept(MediaType.APPLICATION_JSON))
+
+                .andExpect(status().isNoContent())
+
+                .andDo(restDocs.document(
+                        requestCookies(
+                                cookieWithName("accessToken")
+                                        .description("이것은.액세스.토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("fair-id")
+                                        .description("입학설명회 id")
+                        )
+                ));
+
+        verify(deleteAdmissionFairUseCase, times(1)).execute(fairId);
     }
 
 }

--- a/src/test/java/com/bamdoliro/maru/shared/util/ControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/shared/util/ControllerTest.java
@@ -41,6 +41,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Disabled;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -96,6 +97,9 @@ public abstract class ControllerTest {
 
     @MockitoBean
     protected UpdateQuestionUseCase updateQuestionUseCase;
+
+    @MockitoBean
+    protected QueryQuestionUseCase queryQuestionUseCase;
 
     @MockitoBean
     protected QueryQuestionListUseCase queryQuestionListUseCase;
@@ -194,7 +198,10 @@ public abstract class ControllerTest {
     protected AttendAdmissionFairUseCase attendAdmissionFairUseCase;
 
     @MockitoBean
-    protected QueryQuestionUseCase queryQuestionUseCase;
+    protected UpdateAdmissionFairUseCase updateAdmissionFairUseCase;
+
+    @MockitoBean
+    protected DeleteAdmissionFairUseCase deleteAdmissionFairUseCase;
 
     @MockitoBean
     protected QueryFairListUseCase queryFairListUseCase;


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #373

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 입학설명회 삭제 및 수정 기능을 만들었습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- 입학설명회 수정용 DTO를 추가했습니다.
- 도메인에 update 메서드를 추가했습니다.
- 입학설명회 수정/삭제 유스케이스 추가했습니다.
- 컨트롤러에 수정/삭제 엔드포인트 추가했습니다.
- 각 유스케이스와 수정/삭제 API에 대한 테스트 코드를 작성했습니다.

<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [x] 테스트를 완료했나요?
- [ ] API 문서를 작성했나요?
- [ ] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

