### PR TITLE
[새기능] 원서 상태 변경 로그

### DIFF
--- a/src/main/java/com/bamdoliro/maru/application/form/ApproveFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/ApproveFormUseCase.java
@@ -2,6 +2,7 @@ package com.bamdoliro.maru.application.form;
 
 import com.bamdoliro.maru.domain.form.domain.Form;
 import com.bamdoliro.maru.domain.form.service.FormFacade;
+import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.shared.annotation.UseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,8 +14,9 @@ public class ApproveFormUseCase {
     private final FormFacade formFacade;
 
     @Transactional
-    public void execute(Long id) {
+    public void execute(Long id, User user) {
         Form form = formFacade.getForm(id);
+        form.isAdmin(user);
         form.approve();
     }
 }

--- a/src/main/java/com/bamdoliro/maru/application/form/ReceiveFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/ReceiveFormUseCase.java
@@ -2,6 +2,7 @@ package com.bamdoliro.maru.application.form;
 
 import com.bamdoliro.maru.domain.form.domain.Form;
 import com.bamdoliro.maru.domain.form.service.FormFacade;
+import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.shared.annotation.UseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,8 +14,9 @@ public class ReceiveFormUseCase {
     private final FormFacade formFacade;
 
     @Transactional
-    public void execute(Long formId) {
+    public void execute(Long formId, User user) {
         Form form = formFacade.getForm(formId);
+        form.isAdmin(user);
         form.receive();
     }
 }

--- a/src/main/java/com/bamdoliro/maru/application/form/RejectFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/RejectFormUseCase.java
@@ -2,6 +2,7 @@ package com.bamdoliro.maru.application.form;
 
 import com.bamdoliro.maru.domain.form.domain.Form;
 import com.bamdoliro.maru.domain.form.service.FormFacade;
+import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.shared.annotation.UseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,8 +14,9 @@ public class RejectFormUseCase {
     private final FormFacade formFacade;
 
     @Transactional
-    public void execute(Long id) {
+    public void execute(Long id, User user) {
         Form form = formFacade.getForm(id);
+        form.isAdmin(user);
         form.reject();
     }
 }

--- a/src/main/java/com/bamdoliro/maru/domain/form/domain/Form.java
+++ b/src/main/java/com/bamdoliro/maru/domain/form/domain/Form.java
@@ -131,6 +131,12 @@ public class Form extends BaseTimeEntity {
         }
     }
 
+    public void isAdmin(User user){
+        if(!user.isAdmin()) {
+            throw new AuthorityMismatchException();
+        }
+    }
+
     public void isApplicantOrAdmin(User user) {
         if (!user.isAdmin() && !this.user.equals(user)) {
             throw new AuthorityMismatchException();

--- a/src/main/java/com/bamdoliro/maru/domain/log/AdminFormStatusChangeLog.java
+++ b/src/main/java/com/bamdoliro/maru/domain/log/AdminFormStatusChangeLog.java
@@ -1,0 +1,55 @@
+package com.bamdoliro.maru.domain.log;
+
+import com.bamdoliro.maru.domain.form.domain.Form;
+import com.bamdoliro.maru.domain.form.domain.type.FormStatus;
+import com.bamdoliro.maru.domain.user.domain.User;
+import com.bamdoliro.maru.shared.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "tbl_admin_form_status_change_log")
+@Entity
+public class AdminFormStatusChangeLog extends BaseTimeEntity {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long id;
+
+    @Column(nullable = false)
+    private String clientIp;
+
+    @Column(nullable = false)
+    private String userAgent;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, name = "form_id")
+    private Form form;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private FormStatus beforeStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private FormStatus afterStatus;
+
+    @Builder
+    public AdminFormStatusChangeLog(String clientIp, String userAgent, User user, Form form, FormStatus beforeStatus, FormStatus afterStatus) {
+        this.clientIp = clientIp;
+        this.userAgent = userAgent;
+        this.user = user;
+        this.form = form;
+        this.beforeStatus = beforeStatus;
+        this.afterStatus = afterStatus;
+    }
+
+}

--- a/src/main/java/com/bamdoliro/maru/domain/log/AdminFromViewLog.java
+++ b/src/main/java/com/bamdoliro/maru/domain/log/AdminFromViewLog.java
@@ -5,6 +5,7 @@ import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.shared.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -32,6 +33,7 @@ public class AdminFromViewLog extends BaseTimeEntity {
     @JoinColumn(nullable = false, name = "form_id")
     private Form form;
 
+    @Builder
     public AdminFromViewLog(String clientIp, String userAgent, User user, Form form) {
         this.clientIp = clientIp;
         this.userAgent = userAgent;

--- a/src/main/java/com/bamdoliro/maru/infrastructure/aop/log/LogAspect.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/aop/log/LogAspect.java
@@ -41,6 +41,7 @@ public class LogAspect {
     private final FormUpdateLogRepository formUpdateLogRepository;
     private final UpdatedFieldRepository updatedFieldRepository;
     private final AdminFormViewLogRepository adminLookupFormLogRepository;
+    private final AdminFormStatusChangeLogRepository adminFormStatusChangeLogRepository;
 
 
     @AfterReturning(value = "execution(* com.bamdoliro.maru.application.auth.LogInUseCase.execute(..))")
@@ -91,6 +92,42 @@ public class LogAspect {
 
             adminLookupFormLogRepository.save(log);
         }
+    }
+
+    @Around(
+            value = "execution(* com.bamdoliro.maru.application.form.ApproveFormUseCase.execute(..)) || " +
+                    "execution(* com.bamdoliro.maru.application.form.RejectFormUseCase.execute(..)) || " +
+                    "execution(* com.bamdoliro.maru.application.form.ReceiveFormUseCase.execute(..))"
+    )
+    public void logChangeFormStatus(ProceedingJoinPoint joinPoint) throws Throwable {
+        Object[] args = joinPoint.getArgs();
+
+        User user = (User) args[1];
+
+        Long formId = (Long) args[0];
+
+        Form form = formFacade.getForm(formId);
+
+        HttpServletRequest request = getCurrentHttpRequest();
+        String clientIp = getClientIp(request);
+        String userAgent = getUserAgent(request);
+
+        FormStatus beforeStatus = form.getStatus();
+
+        joinPoint.proceed();
+
+        FormStatus afterStatus = form.getStatus();
+
+        AdminFormStatusChangeLog log = AdminFormStatusChangeLog.builder()
+                .clientIp(clientIp)
+                .userAgent(userAgent)
+                .user(user)
+                .form(form)
+                .beforeStatus(beforeStatus)
+                .afterStatus(afterStatus)
+                .build();
+
+        adminFormStatusChangeLogRepository.save(log);
     }
 
     @Around(value = "execution(* com.bamdoliro.maru.application.form.UpdateFormUseCase.execute(..))")

--- a/src/main/java/com/bamdoliro/maru/infrastructure/persistence/log/AdminFormStatusChangeLogRepository.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/persistence/log/AdminFormStatusChangeLogRepository.java
@@ -1,0 +1,7 @@
+package com.bamdoliro.maru.infrastructure.persistence.log;
+
+import com.bamdoliro.maru.domain.log.AdminFormStatusChangeLog;
+import org.springframework.data.repository.CrudRepository;
+
+public interface AdminFormStatusChangeLogRepository extends CrudRepository<AdminFormStatusChangeLog, Long> {
+}

--- a/src/main/java/com/bamdoliro/maru/presentation/form/AdminFormController.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/form/AdminFormController.java
@@ -56,7 +56,7 @@ public class AdminFormController {
             @AuthenticationPrincipal(authority = Authority.ADMIN) User user,
             @PathVariable(name = "form-id") Long formId
     ) {
-        approveFormUseCase.execute(formId);
+        approveFormUseCase.execute(formId, user);
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
@@ -65,7 +65,7 @@ public class AdminFormController {
             @AuthenticationPrincipal(authority = Authority.ADMIN) User user,
             @PathVariable(name = "form-id") Long formId
     ) {
-        rejectFormUseCase.execute(formId);
+        rejectFormUseCase.execute(formId, user);
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
@@ -74,7 +74,7 @@ public class AdminFormController {
             @AuthenticationPrincipal(authority = Authority.ADMIN) User user,
             @PathVariable(name = "form-id") Long formId
     ) {
-        receiveFormUseCase.execute(formId);
+        receiveFormUseCase.execute(formId, user);
     }
 
     @GetMapping("/review")

--- a/src/test/java/com/bamdoliro/maru/application/form/ApproveFormUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/ApproveFormUseCaseTest.java
@@ -5,7 +5,9 @@ import com.bamdoliro.maru.domain.form.domain.type.FormStatus;
 import com.bamdoliro.maru.domain.form.domain.type.FormType;
 import com.bamdoliro.maru.domain.form.exception.FormNotFoundException;
 import com.bamdoliro.maru.domain.form.service.FormFacade;
+import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.shared.fixture.FormFixture;
+import com.bamdoliro.maru.shared.fixture.UserFixture;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -31,10 +33,11 @@ class ApproveFormUseCaseTest {
     void 원서를_승인한다() {
         // given
         Form form = FormFixture.createForm(FormType.REGULAR);
+        User user = UserFixture.createAdminUser();
         given(formFacade.getForm(form.getId())).willReturn(form);
 
         // when
-        approveFormUseCase.execute(form.getId());
+        approveFormUseCase.execute(form.getId(), user);
 
         // then
         verify(formFacade).getForm(form.getId());
@@ -45,11 +48,12 @@ class ApproveFormUseCaseTest {
     void 원서를_승인할_때_원서가_없으면_에러가_발생한다() {
         // given
         Form form = FormFixture.createForm(FormType.REGULAR);
+        User user = UserFixture.createAdminUser();
         form.submit();
         willThrow(new FormNotFoundException()).given(formFacade).getForm(form.getId());
         
         // when and then
-        assertThrows(FormNotFoundException.class, () -> approveFormUseCase.execute(form.getId()));
+        assertThrows(FormNotFoundException.class, () -> approveFormUseCase.execute(form.getId(), user));
         assertEquals(form.getStatus(), FormStatus.FINAL_SUBMITTED);
     }
 }

--- a/src/test/java/com/bamdoliro/maru/application/form/ApproveFormUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/ApproveFormUseCaseTest.java
@@ -1,5 +1,6 @@
 package com.bamdoliro.maru.application.form;
 
+import com.bamdoliro.maru.domain.auth.exception.AuthorityMismatchException;
 import com.bamdoliro.maru.domain.form.domain.Form;
 import com.bamdoliro.maru.domain.form.domain.type.FormStatus;
 import com.bamdoliro.maru.domain.form.domain.type.FormType;
@@ -55,5 +56,16 @@ class ApproveFormUseCaseTest {
         // when and then
         assertThrows(FormNotFoundException.class, () -> approveFormUseCase.execute(form.getId(), user));
         assertEquals(form.getStatus(), FormStatus.FINAL_SUBMITTED);
+    }
+
+    @Test
+    void 원서를_승인할_때_어드민이_아니면_에러가_발생한다(){
+        //given
+        Form form = FormFixture.createForm(FormType.REGULAR);
+        User user = UserFixture.createUser();
+        given(formFacade.getForm(form.getId())).willReturn(form);
+
+        //when and then
+        assertThrows(AuthorityMismatchException.class, () -> approveFormUseCase.execute(form.getId(), user));
     }
 }

--- a/src/test/java/com/bamdoliro/maru/application/form/ReceiveFormUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/ReceiveFormUseCaseTest.java
@@ -1,5 +1,6 @@
 package com.bamdoliro.maru.application.form;
 
+import com.bamdoliro.maru.domain.auth.exception.AuthorityMismatchException;
 import com.bamdoliro.maru.domain.form.domain.Form;
 import com.bamdoliro.maru.domain.form.domain.type.FormStatus;
 import com.bamdoliro.maru.domain.form.domain.type.FormType;
@@ -55,5 +56,16 @@ class ReceiveFormUseCaseTest {
         // when and then
         assertThrows(FormNotFoundException.class, () -> receiveFormUseCase.execute(form.getId(), user));
         assertEquals(form.getStatus(), FormStatus.APPROVED);
+    }
+
+    @Test
+    void 원서를_접수할_때_어드민이_아니면_에러가_발생한다(){
+        //given
+        Form form = FormFixture.createForm(FormType.REGULAR);
+        User user = UserFixture.createUser();
+        given(formFacade.getForm(form.getId())).willReturn(form);
+
+        // when and then
+        assertThrows(AuthorityMismatchException.class, () -> receiveFormUseCase.execute(form.getId(), user));
     }
 }

--- a/src/test/java/com/bamdoliro/maru/application/form/ReceiveFormUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/ReceiveFormUseCaseTest.java
@@ -5,7 +5,9 @@ import com.bamdoliro.maru.domain.form.domain.type.FormStatus;
 import com.bamdoliro.maru.domain.form.domain.type.FormType;
 import com.bamdoliro.maru.domain.form.exception.FormNotFoundException;
 import com.bamdoliro.maru.domain.form.service.FormFacade;
+import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.shared.fixture.FormFixture;
+import com.bamdoliro.maru.shared.fixture.UserFixture;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -31,10 +33,11 @@ class ReceiveFormUseCaseTest {
     void 원서를_접수한다() {
         // given
         Form form = FormFixture.createForm(FormType.REGULAR);
+        User user = UserFixture.createAdminUser();
         given(formFacade.getForm(form.getId())).willReturn(form);
 
         // when
-        receiveFormUseCase.execute(form.getId());
+        receiveFormUseCase.execute(form.getId(), user);
 
         // then
         verify(formFacade).getForm(form.getId());
@@ -45,11 +48,12 @@ class ReceiveFormUseCaseTest {
     void 원서를_접수할_때_원서가_없으면_에러가_발생한다() {
         // given
         Form form = FormFixture.createForm(FormType.REGULAR);
+        User user = UserFixture.createAdminUser();
         form.approve();
         willThrow(new FormNotFoundException()).given(formFacade).getForm(form.getId());
 
         // when and then
-        assertThrows(FormNotFoundException.class, () -> receiveFormUseCase.execute(form.getId()));
+        assertThrows(FormNotFoundException.class, () -> receiveFormUseCase.execute(form.getId(), user));
         assertEquals(form.getStatus(), FormStatus.APPROVED);
     }
 }

--- a/src/test/java/com/bamdoliro/maru/application/form/RejectFormUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/RejectFormUseCaseTest.java
@@ -1,5 +1,6 @@
 package com.bamdoliro.maru.application.form;
 
+import com.bamdoliro.maru.domain.auth.exception.AuthorityMismatchException;
 import com.bamdoliro.maru.domain.form.domain.Form;
 import com.bamdoliro.maru.domain.form.domain.type.FormStatus;
 import com.bamdoliro.maru.domain.form.domain.type.FormType;
@@ -54,6 +55,17 @@ class RejectFormUseCaseTest {
 
         // when and then
         assertThrows(FormNotFoundException.class, () -> rejectFormUseCase.execute(form.getId(), user));
-        assertEquals(form.getStatus(), FormStatus.FINAL_SUBMITTED);
+        assertEquals(form.getStatus(), FormStatus.REJECTED);
+    }
+
+    @Test
+    void 원서를_반려할_때_어드민이_아니면_에러가_발생한다(){
+        //given
+        Form form = FormFixture.createForm(FormType.REGULAR);
+        User user = UserFixture.createUser();
+        given(formFacade.getForm(form.getId())).willReturn(form);
+
+        //when and then
+        assertThrows(AuthorityMismatchException.class, () -> rejectFormUseCase.execute(form.getId(), user));
     }
 }

--- a/src/test/java/com/bamdoliro/maru/application/form/RejectFormUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/RejectFormUseCaseTest.java
@@ -5,7 +5,9 @@ import com.bamdoliro.maru.domain.form.domain.type.FormStatus;
 import com.bamdoliro.maru.domain.form.domain.type.FormType;
 import com.bamdoliro.maru.domain.form.exception.FormNotFoundException;
 import com.bamdoliro.maru.domain.form.service.FormFacade;
+import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.shared.fixture.FormFixture;
+import com.bamdoliro.maru.shared.fixture.UserFixture;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -31,10 +33,11 @@ class RejectFormUseCaseTest {
     void 원서를_반려한다() {
         // given
         Form form = FormFixture.createForm(FormType.REGULAR);
+        User user = UserFixture.createAdminUser();
         given(formFacade.getForm(form.getId())).willReturn(form);
 
         // when
-        rejectFormUseCase.execute(form.getId());
+        rejectFormUseCase.execute(form.getId(), user);
 
         // then
         verify(formFacade).getForm(form.getId());
@@ -45,11 +48,12 @@ class RejectFormUseCaseTest {
     void 원서를_반려할_때_원서가_없으면_에러가_발생한다() {
         // given
         Form form = FormFixture.createForm(FormType.REGULAR);
-        form.submit();
+        User user = UserFixture.createAdminUser();
+        form.reject();
         willThrow(new FormNotFoundException()).given(formFacade).getForm(form.getId());
 
         // when and then
-        assertThrows(FormNotFoundException.class, () -> rejectFormUseCase.execute(form.getId()));
+        assertThrows(FormNotFoundException.class, () -> rejectFormUseCase.execute(form.getId(), user));
         assertEquals(form.getStatus(), FormStatus.FINAL_SUBMITTED);
     }
 }

--- a/src/test/java/com/bamdoliro/maru/presentation/form/AdminFormControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/presentation/form/AdminFormControllerTest.java
@@ -45,7 +45,7 @@ class AdminFormControllerTest extends RestDocsTestSupport {
 
         given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
-        willDoNothing().given(approveFormUseCase).execute(formId);
+        willDoNothing().given(approveFormUseCase).execute(formId, user);
 
         mockMvc.perform(patch("/admin/forms/{form-id}/approve", formId)
                         .cookie(AuthFixture.createAuthCookie())
@@ -60,7 +60,7 @@ class AdminFormControllerTest extends RestDocsTestSupport {
                         pathParameters(parameterWithName("form-id").description("승인할 원서의 id"))
                 ));
 
-        verify(approveFormUseCase, times(1)).execute(formId);
+        verify(approveFormUseCase, times(1)).execute(formId, user);
     }
 
     @Test
@@ -70,7 +70,7 @@ class AdminFormControllerTest extends RestDocsTestSupport {
 
         given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
-        doThrow(new FormNotFoundException()).when(approveFormUseCase).execute(formId);
+        doThrow(new FormNotFoundException()).when(approveFormUseCase).execute(formId, user);
 
         mockMvc.perform(patch("/admin/forms/{form-id}/approve", formId)
                         .cookie(AuthFixture.createAuthCookie())
@@ -79,7 +79,7 @@ class AdminFormControllerTest extends RestDocsTestSupport {
                 .andExpect(status().isNotFound())
                 .andDo(restDocs.document());
 
-        verify(approveFormUseCase, times(1)).execute(formId);
+        verify(approveFormUseCase, times(1)).execute(formId, user);
     }
 
     @Test
@@ -89,7 +89,7 @@ class AdminFormControllerTest extends RestDocsTestSupport {
 
         given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
-        willDoNothing().given(rejectFormUseCase).execute(formId);
+        willDoNothing().given(rejectFormUseCase).execute(formId, user);
 
         mockMvc.perform(patch("/admin/forms/{form-id}/reject", formId)
                         .cookie(AuthFixture.createAuthCookie())
@@ -104,7 +104,7 @@ class AdminFormControllerTest extends RestDocsTestSupport {
                         pathParameters(parameterWithName("form-id").description("반려할 원서의 id"))
                 ));
 
-        verify(rejectFormUseCase, times(1)).execute(formId);
+        verify(rejectFormUseCase, times(1)).execute(formId, user);
     }
 
     @Test
@@ -114,7 +114,7 @@ class AdminFormControllerTest extends RestDocsTestSupport {
 
         given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
-        doThrow(new FormNotFoundException()).when(rejectFormUseCase).execute(formId);
+        doThrow(new FormNotFoundException()).when(rejectFormUseCase).execute(formId, user);
 
         mockMvc.perform(patch("/admin/forms/{form-id}/reject", formId)
                         .cookie(AuthFixture.createAuthCookie())
@@ -123,7 +123,7 @@ class AdminFormControllerTest extends RestDocsTestSupport {
                 .andExpect(status().isNotFound())
                 .andDo(restDocs.document());
 
-        verify(rejectFormUseCase, times(1)).execute(formId);
+        verify(rejectFormUseCase, times(1)).execute(formId, user);
     }
 
     @Test
@@ -133,7 +133,7 @@ class AdminFormControllerTest extends RestDocsTestSupport {
 
         given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
-        willDoNothing().given(receiveFormUseCase).execute(formId);
+        willDoNothing().given(receiveFormUseCase).execute(formId, user);
 
         mockMvc.perform(patch("/admin/forms/{form-id}/receive", formId)
                         .cookie(AuthFixture.createAuthCookie())
@@ -148,7 +148,7 @@ class AdminFormControllerTest extends RestDocsTestSupport {
                         pathParameters(parameterWithName("form-id").description("접수할 원서의 id"))
                 ));
 
-        verify(receiveFormUseCase, times(1)).execute(formId);
+        verify(receiveFormUseCase, times(1)).execute(formId, user);
     }
 
     @Test
@@ -158,7 +158,7 @@ class AdminFormControllerTest extends RestDocsTestSupport {
 
         given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
-        doThrow(new FormNotFoundException()).when(receiveFormUseCase).execute(formId);
+        doThrow(new FormNotFoundException()).when(receiveFormUseCase).execute(formId, user);
 
         mockMvc.perform(patch("/admin/forms/{form-id}/receive", formId)
                         .cookie(AuthFixture.createAuthCookie())
@@ -167,7 +167,7 @@ class AdminFormControllerTest extends RestDocsTestSupport {
                 .andExpect(status().isNotFound())
                 .andDo(restDocs.document());
 
-        verify(receiveFormUseCase, times(1)).execute(formId);
+        verify(receiveFormUseCase, times(1)).execute(formId, user);
     }
 
     @Test


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #384 

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 어드민이 원서 상태를 변경하면 로그가 남도록 했습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- 어드민이 원서 상태를 변경하면 로그가 남도록 했습니다.
- 어드민 확인 도메인로직을 추가했습니다.


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [ ] 테스트를 완료했나요?
- [ ] API 문서를 작성했나요?
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

