### PR TITLE
feat: 회원가입 임시 차단

### DIFF
--- a/src/main/java/com/bamdoliro/maru/application/user/SignUpUserUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/user/SignUpUserUseCase.java
@@ -3,6 +3,7 @@ package com.bamdoliro.maru.application.user;
 import com.bamdoliro.maru.domain.user.domain.SignUpVerification;
 import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.domain.user.domain.type.Authority;
+import com.bamdoliro.maru.domain.user.exception.SignUpTemporarilyDisabledException;
 import com.bamdoliro.maru.domain.user.exception.UserAlreadyExistsException;
 import com.bamdoliro.maru.domain.user.exception.VerifyingHasFailedException;
 import com.bamdoliro.maru.infrastructure.persistence.user.SignUpVerificationRepository;
@@ -21,6 +22,11 @@ public class SignUpUserUseCase {
 
     @Transactional
     public void execute(SignUpUserRequest request) {
+        // TODO: 임시 회원가입 차단. 재개 시 이 블록을 원래 코드로 되돌리기
+        if (true) {
+            throw new SignUpTemporarilyDisabledException();
+        }
+
         validate(request);
 
         userRepository.save(

--- a/src/main/java/com/bamdoliro/maru/domain/user/exception/SignUpTemporarilyDisabledException.java
+++ b/src/main/java/com/bamdoliro/maru/domain/user/exception/SignUpTemporarilyDisabledException.java
@@ -1,0 +1,11 @@
+package com.bamdoliro.maru.domain.user.exception;
+
+import com.bamdoliro.maru.domain.user.exception.error.UserErrorProperty;
+import com.bamdoliro.maru.shared.error.MaruException;
+
+public class SignUpTemporarilyDisabledException extends MaruException {
+
+    public SignUpTemporarilyDisabledException() {
+        super(UserErrorProperty.SIGNUP_TEMPORARILY_DISABLED);
+    }
+}

--- a/src/main/java/com/bamdoliro/maru/domain/user/exception/error/UserErrorProperty.java
+++ b/src/main/java/com/bamdoliro/maru/domain/user/exception/error/UserErrorProperty.java
@@ -13,6 +13,7 @@ public enum UserErrorProperty implements ErrorProperty {
     PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "비밀번호가 틀렸습니다."),
     VERIFYING_HAS_FAILED(HttpStatus.UNAUTHORIZED, "전화번호 인증이 실패했습니다."),
     VERIFICATION_CODE_MISMATCH(HttpStatus.UNAUTHORIZED, "전화번호 인증 코드가 틀렸습니다."),
+    SIGNUP_TEMPORARILY_DISABLED(HttpStatus.SERVICE_UNAVAILABLE, "현재 회원가입이 일시적으로 중단되었습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/test/java/com/bamdoliro/maru/application/user/SignUpUserUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/user/SignUpUserUseCaseTest.java
@@ -2,12 +2,14 @@ package com.bamdoliro.maru.application.user;
 
 import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.domain.user.domain.SignUpVerification;
+import com.bamdoliro.maru.domain.user.exception.SignUpTemporarilyDisabledException;
 import com.bamdoliro.maru.domain.user.exception.UserAlreadyExistsException;
 import com.bamdoliro.maru.domain.user.exception.VerifyingHasFailedException;
 import com.bamdoliro.maru.infrastructure.persistence.user.UserRepository;
 import com.bamdoliro.maru.infrastructure.persistence.user.SignUpVerificationRepository;
 import com.bamdoliro.maru.presentation.user.dto.request.SignUpUserRequest;
 import com.bamdoliro.maru.shared.fixture.UserFixture;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -38,6 +40,21 @@ class SignUpUserUseCaseTest {
     private UserRepository userRepository;
 
     @Test
+    void 회원가입이_임시로_차단되어_있다() {
+        // given
+        SignUpUserRequest request = new SignUpUserRequest("전화번호", "김밤돌", "비밀번호");
+
+        // when and then
+        assertThrows(SignUpTemporarilyDisabledException.class,
+                () -> signUpUserUseCase.execute(request));
+
+        verify(userRepository, never()).existsByPhoneNumber(any());
+        verify(userRepository, never()).save(any());
+    }
+
+    // TODO: 회원가입 임시 차단이 해제되면 @Disabled를 제거하고 원래대로 검증
+    @Disabled("회원가입 임시 차단으로 인해 원래 로직에 도달하지 않음")
+    @Test
     void 유저를_생성한다() {
         // given
         User user = UserFixture.createUser();
@@ -59,6 +76,7 @@ class SignUpUserUseCaseTest {
         assertEquals(user.getPhoneNumber(), savedUser.getPhoneNumber());
     }
 
+    @Disabled("회원가입 임시 차단으로 인해 원래 로직에 도달하지 않음")
     @Test
     void 전화번호_인증을_요청하지_않았거나_만료되었다면_에러가_발생한다() {
         // given
@@ -74,6 +92,7 @@ class SignUpUserUseCaseTest {
         verify(userRepository, never()).save(any());
     }
 
+    @Disabled("회원가입 임시 차단으로 인해 원래 로직에 도달하지 않음")
     @Test
     void 전화번호_인증을_하지_않았다면_에러가_발생한다() {
         // given
@@ -91,6 +110,7 @@ class SignUpUserUseCaseTest {
         verify(userRepository, never()).save(any());
     }
 
+    @Disabled("회원가입 임시 차단으로 인해 원래 로직에 도달하지 않음")
     @Test
     void 이미_유저가_있다면_에러가_발생한다() {
         // given


### PR DESCRIPTION
## Summary
- 운영 이슈 대응을 위해 회원가입 API(`POST /users`) 호출 시 503과 함께 차단 메시지를 반환하도록 임시 조치
- `SignUpUserUseCase.execute()` 진입 시 바로 `SignUpTemporarilyDisabledException`을 던지도록 처리
- 재개 시 `SignUpUserUseCase`의 `if (true) { throw ... }` 블록만 제거하면 원래 로직으로 복원됨

## Test plan
- [ ] `POST /users` 호출 시 503과 회원가입 중단 메시지가 반환되는지 확인
- [ ] 기존 회원가입 로직(인증 검증, 저장)이 재개 시 정상 동작하는지 확인