### PR TITLE
[개선] 입학 원서에서 1학년 정보 성적 표시

### DIFF
--- a/src/main/java/com/bamdoliro/maru/application/form/ExportFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/ExportFormUseCase.java
@@ -43,6 +43,8 @@ public class ExportFormUseCase {
         SubjectMap subjectMap = form.getGrade().getSubjectList().getSubjectMap();
         Map<String, Object> formMap = Map.of(
                 "form", form,
+                "grade11", subjectMap.getSubjectListOf(1, 1),
+                "grade12", subjectMap.getSubjectListOf(1, 2),
                 "grade21", subjectMap.getSubjectListOf(2, 1),
                 "grade22", subjectMap.getSubjectListOf(2, 2),
                 "grade31", subjectMap.getSubjectListOf(3, 1),

--- a/src/main/resources/templates/form.html
+++ b/src/main/resources/templates/form.html
@@ -167,9 +167,13 @@
     </tr>
     <tr th:unless="${form.education.isQualificationExamination()}">
         <th scope="row" class="ba" rowspan="2">1</th>
-        <td class="ba disabled" colspan="2">-</td>
-        <td class="ba disabled" colspan="3"></td>
-        <td class="ba disabled" colspan="1"></td>
+        <td class="ba" colspan="2">1</td>
+        <td class="ba" colspan="3"
+            th:unless="${form.education.isQualificationExamination()}"
+            th:text="${grade11.size()}"></td>
+        <td class="ba" colspan="1"
+            th:unless="${form.education.isQualificationExamination()}"
+            th:text="${grade11.totalScore()}"></td>
         <td class="ba" rowspan="7" colspan="2"
             th:unless="${form.education.isQualificationExamination()}"
             th:text="${form.score.subjectGradeScore}"></td>
@@ -201,10 +205,19 @@
             th:unless="${form.education.isQualificationExamination()}"
             th:text="${form.score.getFirstRoundScore()}"></td>
     </tr>
-    <tr>
+    <tr th:if="${form.education.isQualificationExamination()}">
         <td class="ba disabled" colspan="2">-</td>
         <td class="ba disabled" colspan="3"></td>
         <td class="ba disabled" colspan="1"></td>
+    </tr>
+    <tr th:unless="${form.education.isQualificationExamination()}">
+        <td class="ba" colspan="2">2</td>
+        <td class="ba" colspan="3"
+            th:unless="${form.education.isQualificationExamination()}"
+            th:text="${grade12.size()}"></td>
+        <td class="ba" colspan="1"
+            th:unless="${form.education.isQualificationExamination()}"
+            th:text="${grade12.totalScore()}"></td>
     </tr>
     <tr th:if="${form.education.isQualificationExamination()}">
         <th scope="row" class="ba" rowspan="2">2</th>
@@ -303,9 +316,9 @@
         <th scope="row" class="ba">계</th>
         <td class="ba disabled" colspan="2"></td>
         <td class="ba" colspan="3"
-            th:text="${grade21.size() + grade22.size() + grade31.size()}"></td>
+            th:text="${grade11.size() + grade12.size() + grade21.size() + grade22.size() + grade31.size()}"></td>
         <td class="ba" colspan="1"
-            th:text="${grade21.totalScore() + grade22.totalScore() + grade31.totalScore()}"></td>
+            th:text="${grade11.totalScore() + grade12.totalScore() + grade21.totalScore() + grade22.totalScore() + grade31.totalScore()}"></td>
         <td class="ba" colspan="1"
             th:text="${form.grade.getTotalAbsenceCount()}"></td>
         <td class="ba" colspan="2"


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 입학 원서에서 1학년 정보 성적이 누락되어 있어 수정했습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- ExportFormUseCase에서 formMap에 grade11, grade12 추가
- form.html에서 비활성화 되어 있던 1학년 성적 표시하도록 수정


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [x] 테스트를 완료했나요?
- [ ] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

