### PR TITLE
feat: 회원가입 임시 재차단

### DIFF
--- a/src/main/java/com/bamdoliro/maru/application/user/SignUpUserUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/user/SignUpUserUseCase.java
@@ -22,10 +22,10 @@ public class SignUpUserUseCase {
 
     @Transactional
     public void execute(SignUpUserRequest request) {
-        // TODO: 임시 회원가입 차단 해제. 재차단 필요 시 주석 해제
-        // if (true) {
-        //     throw new SignUpTemporarilyDisabledException();
-        // }
+        // TODO: 임시 회원가입 차단. 재개 시 이 블록을 원래 코드로 되돌리기
+        if (true) {
+            throw new SignUpTemporarilyDisabledException();
+        }
 
         validate(request);
 

--- a/src/test/java/com/bamdoliro/maru/application/user/SignUpUserUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/user/SignUpUserUseCaseTest.java
@@ -39,8 +39,6 @@ class SignUpUserUseCaseTest {
     @Mock
     private UserRepository userRepository;
 
-    // TODO: 회원가입 임시 차단을 재개하면 @Disabled 제거
-    @Disabled("회원가입 임시 차단이 해제되어 있어 이 테스트는 통과하지 않음")
     @Test
     void 회원가입이_임시로_차단되어_있다() {
         // given
@@ -54,6 +52,8 @@ class SignUpUserUseCaseTest {
         verify(userRepository, never()).save(any());
     }
 
+    // TODO: 회원가입 임시 차단이 해제되면 @Disabled를 제거하고 원래대로 검증
+    @Disabled("회원가입 임시 차단으로 인해 원래 로직에 도달하지 않음")
     @Test
     void 유저를_생성한다() {
         // given
@@ -76,6 +76,7 @@ class SignUpUserUseCaseTest {
         assertEquals(user.getPhoneNumber(), savedUser.getPhoneNumber());
     }
 
+    @Disabled("회원가입 임시 차단으로 인해 원래 로직에 도달하지 않음")
     @Test
     void 전화번호_인증을_요청하지_않았거나_만료되었다면_에러가_발생한다() {
         // given
@@ -91,6 +92,7 @@ class SignUpUserUseCaseTest {
         verify(userRepository, never()).save(any());
     }
 
+    @Disabled("회원가입 임시 차단으로 인해 원래 로직에 도달하지 않음")
     @Test
     void 전화번호_인증을_하지_않았다면_에러가_발생한다() {
         // given
@@ -108,6 +110,7 @@ class SignUpUserUseCaseTest {
         verify(userRepository, never()).save(any());
     }
 
+    @Disabled("회원가입 임시 차단으로 인해 원래 로직에 도달하지 않음")
     @Test
     void 이미_유저가_있다면_에러가_발생한다() {
         // given


### PR DESCRIPTION
## Summary
- 운영 이슈 재발로 회원가입 기능을 다시 임시 차단 (#411에서 되돌린 것을 복원)
- 재개 시 참고할 수 있도록 관련 테스트도 원래 차단 상태로 복원

## Test plan
- [x] `./gradlew test --tests SignUpUserUseCaseTest` 통과 확인